### PR TITLE
Potential fix for code scanning alert no. 17: Server-side request forgery

### DIFF
--- a/beetle_backend/src/routes/github.cjs
+++ b/beetle_backend/src/routes/github.cjs
@@ -13,7 +13,8 @@ const {
   searchRepositories,
   getRepositoryTree,
   getFileContent,
-  getRepositoryTreesForAllBranches
+  getRepositoryTreesForAllBranches,
+  isValidOwner
 } = require('../utils/github.cjs');
 const { saveRepository, getRepository } = require('../utils/database.cjs');
 const { asyncHandler } = require('../middleware/errorHandler.cjs');
@@ -667,6 +668,11 @@ router.get('/repositories/:owner/:repo/tree', asyncHandler(async (req, res) => {
 router.get('/repositories/:owner/:repo/trees', asyncHandler(async (req, res) => {
   const { owner, repo } = req.params;
   try {
+    // Validate owner parameter
+    if (!isValidOwner(owner)) {
+      return res.status(400).json({ error: 'Invalid owner parameter' });
+    }
+
     const treesByBranch = await getRepositoryTreesForAllBranches(req.user.accessToken, owner, repo);
     res.json({ treesByBranch });
   } catch (error) {

--- a/beetle_backend/src/utils/github.cjs
+++ b/beetle_backend/src/utils/github.cjs
@@ -17,6 +17,12 @@ const createGitHubClient = (accessToken) => {
   });
 };
 
+// Validate owner parameter
+const isValidOwner = (owner) => {
+  const ownerRegex = /^[a-zA-Z0-9_-]+$/; // Allow alphanumeric, underscores, and hyphens
+  return ownerRegex.test(owner);
+};
+
 // Create GraphQL client
 const createGraphQLClient = (accessToken) => {
   return axios.create({
@@ -989,6 +995,11 @@ const getFileContent = async (accessToken, owner, repo, path, branch = 'main') =
 // Fetch file trees from all branches for a repository
 const getRepositoryTreesForAllBranches = async (accessToken, owner, repo) => {
   try {
+    // Validate owner parameter
+    if (!isValidOwner(owner)) {
+      throw new Error('Invalid owner parameter');
+    }
+
     const cacheKey = `repo_trees_all_branches_${owner}_${repo}`;
     const cached = await getCache(cacheKey);
     if (cached) return cached;


### PR DESCRIPTION
Potential fix for [https://github.com/RAWx18/Beetle/security/code-scanning/17](https://github.com/RAWx18/Beetle/security/code-scanning/17)

To fix the issue, we need to validate or restrict the `owner` parameter before using it in the URL. The best approach is to implement an allow-list of acceptable `owner` values or validate the input against a set of rules (e.g., alphanumeric characters only). This ensures that only legitimate values are used in the API requests.

**Steps to fix:**
1. Add a validation function to check the `owner` parameter against a predefined set of rules or an allow-list.
2. Apply this validation in the `getRepositoryTreesForAllBranches` function before constructing the URL.
3. Update the route handler in `beetle_backend/src/routes/github.cjs` to ensure the `owner` parameter is validated before being passed to the utility function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
