### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/RAWx18/Beetle/security/code-scanning/9](https://github.com/RAWx18/Beetle/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. Since the `build` job does not require write access, we can set the permissions to `contents: read`, which is the minimal permission required for most workflows. This change ensures that the `build` job adheres to the principle of least privilege and does not inherit potentially excessive permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
