### PR TITLE
Fix: Navbar shifted to left on dashboard (#51)

### DIFF
--- a/beetle_frontend/components/dashboard.tsx
+++ b/beetle_frontend/components/dashboard.tsx
@@ -938,7 +938,7 @@ export default function Dashboard({ onSignOut }: DashboardProps) {
         </div>
       )}
       
-      <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 flex justify-center">
         <div className="container flex h-14 items-center">
           {/* Logo & Navigation */}
           <div className="flex items-center space-x-8">
@@ -1107,7 +1107,7 @@ export default function Dashboard({ onSignOut }: DashboardProps) {
               className="space-y-8"
             >
               {/* Welcome Section */}
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between flex flex-wrap">
                 <div>
                   <div className="flex items-center gap-2">
                     <h1 className="text-3xl font-bold">{getGreeting()}, </h1>


### PR DESCRIPTION
This PR fixes the UI issue described in #51 where Navbar on the dashboard page was shifted to left.

🛠 Changes Made:
Applied tailwindcss properties to keep the navbar in the center and ensure responsiveness.

Ensured responsive behavior is maintained for different screen sizes.

✅ How it looks now:
Navbar remains in the center of browser window.
<img width="2052" height="1033" alt="Screenshot From 2025-07-18 15-28-18" src="https://github.com/user-attachments/assets/8c4476e6-709d-4bc4-a1a9-4a065538f387" />


📸 Screenshots:

Closes:
Fixes #51