### PR TITLE
Potential fix for code scanning alert no. 23: Type confusion through parameter tampering

### DIFF
--- a/beetle_backend/src/routes/ai.cjs
+++ b/beetle_backend/src/routes/ai.cjs
@@ -69,6 +69,9 @@ router.post('/import', authMiddleware, upload.array('files'), async (req, res) =
     const { repository_id, branch, source_type } = req.body;
     const files = req.files || [];
     
+    if (!Array.isArray(files)) {
+      return res.status(400).json({ error: 'Invalid files parameter: must be an array' });
+    }
     if (files.length === 0) {
       return res.status(400).json({ error: 'No files provided' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/RAWx18/Beetle/security/code-scanning/23](https://github.com/RAWx18/Beetle/security/code-scanning/23)

To fix this problem, we should ensure that the `files` variable is always an array before performing any array operations on it. Specifically, after assigning `req.files` to `files`, we should check its type and, if it is not an array, set it to an empty array or otherwise reject the request. This prevents type confusion and ensures that any tampering (such as submitting a string or other type in place of the expected array) does not lead to unexpected behavior or errors.

The fix should be applied in `beetle_backend/src/routes/ai.cjs`, in the `/import` route handler, after line 70 where `const files = req.files || [];` is set. We should check if `Array.isArray(files)` and handle non-array input appropriately, e.g., by rejecting the request with a 400 status and error message.

No additional methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
