### PR TITLE
Potential fix for code scanning alert no. 21: Use of externally-controlled format string

### DIFF
--- a/beetle_backend/src/routes/webhooks.cjs
+++ b/beetle_backend/src/routes/webhooks.cjs
@@ -115,7 +115,7 @@ router.post('/github',
       });
       
     } catch (error) {
-      console.error(`❌ Error processing webhook ${event}:`, error);
+      console.error('❌ Error processing webhook %s:', event, error);
       webhookEvents.processed(event, delivery, false, error);
       
       res.status(500).json({


### PR DESCRIPTION
Potential fix for [https://github.com/RAWx18/Beetle/security/code-scanning/21](https://github.com/RAWx18/Beetle/security/code-scanning/21)

To fix the issue, the untrusted `event` variable should not be directly interpolated into the log message. Instead, we should use a `%s` specifier in the format string and pass `event` as a separate argument to `console.error`. This ensures that any special characters in `event` are safely rendered as a string, preventing malformed log messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
