### PR TITLE
Potential fix for code scanning alert no. 19: Use of externally-controlled format string

### DIFF
--- a/beetle_backend/src/routes/github.cjs
+++ b/beetle_backend/src/routes/github.cjs
@@ -1095,7 +1095,7 @@ router.get('/repositories/:owner/:repo/branches/:branch', asyncHandler(async (re
     const branchPullRequests = pullRequests;
 
     // Debug logging
-    console.log(`[Branch Data] ${owner}/${repo}/${branch}:`, {
+    console.log('[Branch Data] %s/%s/%s:', owner, repo, branch, {
       commitsCount: commits.length,
       issuesCount: branchIssues.length,
       pullRequestsCount: branchPullRequests.length,


### PR DESCRIPTION
Potential fix for [https://github.com/RAWx18/Beetle/security/code-scanning/19](https://github.com/RAWx18/Beetle/security/code-scanning/19)

To fix the issue, sanitize the user-controlled input (`owner`, `repo`, and `branch`) before embedding it into the format string. Use the `%s` format specifier and pass the sanitized values as arguments to `console.log`. This approach ensures that the format string is not vulnerable to unintended interpretation of format specifiers.

**Steps:**
1. Update the `console.log` statement (line 1098) to use a static format string with `%s` specifiers.
2. Pass the values of `owner`, `repo`, and `branch` as arguments to `console.log`.
3. No new dependencies or imports are required as this fix utilizes existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
