### PR TITLE
feat(run-script): add unified run script for cross-platform support

### DIFF
--- a/beetle_backend/package.json
+++ b/beetle_backend/package.json
@@ -4,9 +4,9 @@
   "description": "Backend for Beetle - Git-based collaboration with Branch-Level Intelligence",
   "main": "src/index.cjs",
   "scripts": {
-    "start": "node src/index.cjs",
-    "dev": "nodemon src/index.cjs",
-    "dev:stable": "node src/index.cjs",
+    "start": "node setup.js",
+    "dev": "nodemon setup.js",
+    "dev:stable": "node setup.js",
     "setup": "node setup-env.js",
     "setup:quick": "./create-env.sh",
     "test": "jest",

--- a/beetle_backend/setup.bat
+++ b/beetle_backend/setup.bat
@@ -1,0 +1,14 @@
+@echo off
+chcp 65001 > nul
+echo 🚀 Starting Beetle Backend in stable mode...
+echo 📝 This mode prevents server restarts during OAuth
+echo.
+
+:: Kill any existing node processes on port 3001
+echo 🔄 Cleaning up existing processes...
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr :3001') do taskkill /PID %%a /F
+timeout /t 2 >nul
+
+:: Start the backend without nodemon
+echo ✅ Starting backend server...
+node src/index.cjs

--- a/beetle_backend/setup.js
+++ b/beetle_backend/setup.js
@@ -1,0 +1,22 @@
+const { spawn } = require("child_process");
+const os = require("os");
+
+// Check if we're on Windows
+const isWindows = os.platform() === "win32";
+
+// Choose the right script for the OS
+const cmd = isWindows ? "setup.bat" : "bash";
+const args = isWindows ? [] : ["setup.sh"];
+
+// Run the script and show output in the terminal
+const child = spawn(cmd, args, { stdio: "inherit", shell: true });
+
+// Show exit status
+child.on("exit", (code) => {
+  console.log(`✅ Finished with code ${code}`);
+});
+
+// Show error if script fails to start
+child.on("error", (err) => {
+  console.error(`❌ Error: ${err.message}`);
+});


### PR DESCRIPTION
This PR adds a unified run script `setup.js` to support cross-platform development across Linux, macOS, and Windows environments.

 **What’s Included:**

- Created `setup.js` using `child_process.spawn` to execute .sh or .bat based on OS
- Ensures developers can run the backend without worrying about platform-specific scripts
- Updated error handling and live output stream from subprocess
- Helps resolve issues with .sh not being supported natively on Windows

Testing Checklist:

-  Tested on Windows using run scripts
-  Tested on wsl using run scripts
-  Output verified in terminal
-  Validated fallback logic based on OS

🔗 Related Issue:
Closes [#73](https://github.com/RAWx18/Beetle/issues/73)