### PR TITLE
Upgrade ESLint to v9.15.0 to resolve deprecation warning (Issue #74)

### DIFF
--- a/beetle_frontend/package.json
+++ b/beetle_frontend/package.json
@@ -66,7 +66,7 @@
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "8.57.1",
+    "eslint": "^9.15.0",
     "eslint-config-next": "15.4.1",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
This pull request upgrades ESLint from v8.57.1 to v9.15.0 in the beetle_frontend package.json to resolve deprecation warnings identified in Issue #74.

## Changes Made
- Updated ESLint from v8.57.1 to ^9.15.0 in devDependencies
- This resolves the deprecation warning: "eslint@8.57.1: This version is no longer supported"

## Why This Change
- ESLint v8 is no longer supported as per https://eslint.org/version-support
- This addresses part of Issue #74 for replacing deprecated dependencies
- Ensures long-term maintainability, security, and compatibility

## Next Steps
This is the first step in addressing Issue #74. Remaining deprecated dependencies to be updated:
- @humanwhocodes/object-schema@2.0.3 → @eslint/object-schema
- @humanwhocodes/config-array@0.13.0 → @eslint/config-array
- glob@7.2.3 → v9+
- rimraf@3.0.2 → v4+
- inflight@1.0.6 → replace with lru-cache

Resolves: #74 (partial)…pgrade ESLint to v9.15.0 to resolve deprecation warningUpdate package.json

- Updated ESLint from v8.57.1 to v9.15.0 to resolve deprecation warning
- This addresses Issue #74 for replacing deprecated dependencies
- ESLint v8 is no longer supported as per https://eslint.org/version-support
- Next step: Continue updating other deprecated dependencies listed in Issue #74