### PR TITLE
Potential fix for code scanning alert no. 113: Clear-text logging of sensitive information

### DIFF
--- a/packages/caracal/caracal/runtime/entrypoints.py
+++ b/packages/caracal/caracal/runtime/entrypoints.py
@@ -1159,10 +1159,11 @@ def _host_vault_init(_namespace: argparse.Namespace) -> int:
 
     print(f"Vault credentials written to {env_path}")
     print()
-    print(f"  CARACAL_VAULT_SIDECAR_AUTH_SECRET={auth_secret}")
-    print(f"  CARACAL_VAULT_SIDECAR_ENCRYPTION_KEY={encryption_key}")
+    print("  CARACAL_VAULT_SIDECAR_AUTH_SECRET=<redacted>")
+    print("  CARACAL_VAULT_SIDECAR_ENCRYPTION_KEY=<redacted>")
     print()
     print("Back these values up securely — they cannot be recovered if lost.")
+    print("Retrieve them from the .env file in a secure manner; they are not printed to the console.")
     print()
     print("Next step:  caracal up")
     return 0


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/113](https://github.com/Garudex-Labs/caracal/security/code-scanning/113)

Best fix: stop printing secret values to stdout, while preserving command behavior (generate secrets and write them to `.env`). Replace the two lines that echo the secret values with non-sensitive guidance text.

In `packages/caracal/caracal/runtime/entrypoints.py`, within `_host_vault_init` (around lines 1160–1165), keep:
- secret generation,
- `.env` update/write logic,
- success message and next-step message.

Change only the output section so it no longer includes `auth_secret` or `encryption_key` values. Instead print a safe message indicating which keys were written and where, plus backup guidance.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
