### PR TITLE
Potential fix for code scanning alert no. 112: Clear-text logging of sensitive information

### DIFF
--- a/packages/caracal-server/caracal/db/connection.py
+++ b/packages/caracal-server/caracal/db/connection.py
@@ -172,11 +172,7 @@ class DatabaseConnectionManager:
         try:
             with self._engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
-            logger.info(
-                "Connected to PostgreSQL: %s@%s:%s/%s",
-                self.config.user, self.config.host,
-                self.config.port, self.config.database,
-            )
+            logger.info("Connected to PostgreSQL backend")
         except OperationalError as e:
             logger.error("PostgreSQL connection failed: %s", e)
             from caracal.exceptions import CaracalError


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/112](https://github.com/Garudex-Labs/caracal/security/code-scanning/112)

Best practice is to avoid logging raw connection configuration values (user/host/port/database) and instead log a generic success message, or at most non-sensitive high-level state (for example, whether a custom schema is active).  
The single best fix here, without changing runtime behavior, is to replace the detailed success log in `packages/caracal-server/caracal/db/connection.py` (inside `DatabaseConnectionManager.initialize`, around lines 175–179) with a non-sensitive message that does not interpolate config-derived values.

No new methods/imports/dependencies are required. Only the `logger.info(...)` block in that region should be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
