### PR TITLE
Potential fix for code scanning alert no. 110: Clear-text logging of sensitive information

### DIFF
--- a/packages/caracal-server/caracal/db/connection.py
+++ b/packages/caracal-server/caracal/db/connection.py
@@ -173,9 +173,10 @@ class DatabaseConnectionManager:
             with self._engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info(
-                "Connected to PostgreSQL: %s@%s:%s/%s",
-                self.config.user, self.config.host,
-                self.config.port, self.config.database,
+                "Connected to PostgreSQL at %s:%s/%s",
+                self.config.host,
+                self.config.port,
+                self.config.database,
             )
         except OperationalError as e:
             logger.error("PostgreSQL connection failed: %s", e)

--- a/packages/caracal-server/caracal/db/connection.py
+++ b/packages/caracal-server/caracal/db/connection.py
@@ -172,12 +172,7 @@ class DatabaseConnectionManager:
         try:
             with self._engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
-            logger.info(
-                "Connected to PostgreSQL at %s:%s/%s",
-                self.config.host,
-                self.config.port,
-                self.config.database,
-            )
+            logger.info("Connected to PostgreSQL backend")
         except OperationalError as e:
             logger.error("PostgreSQL connection failed: %s", e)
             from caracal.exceptions import CaracalError


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/110](https://github.com/Garudex-Labs/caracal/security/code-scanning/110)

To fix this, stop logging credential-adjacent values in plaintext at connection success. Keep the success log, but remove the username from the message and only log non-sensitive operational context (or a generic success message).

Best minimal fix (no functionality change): in `packages/caracal-server/caracal/db/connection.py`, update the `logger.info(...)` block in `DatabaseConnectionManager.initialize()` so it no longer includes `self.config.user`. Keep host/port/database if needed for diagnostics, or simplify further to a generic connected message. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
