### PR TITLE
Potential fix for code scanning alert no. 122: Uncontrolled data used in path expression

### DIFF
--- a/examples/lynxCapital/_mock/server.py
+++ b/examples/lynxCapital/_mock/server.py
@@ -7,16 +7,20 @@ Lightweight mock HTTP server that serves provider API responses for the demo.
 from __future__ import annotations
 
 import json
+import re
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 _DATA_DIR = Path(__file__).parent
+_SERVICE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _cases: dict[str, dict] = {}
 
 
 def _load(service_id: str) -> dict:
+    if not _SERVICE_ID_RE.fullmatch(service_id):
+        raise KeyError(service_id)
     if service_id not in _cases:
         path = _DATA_DIR / f"{service_id}.mock" / "cases.json"
         if not path.exists():


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/122](https://github.com/Garudex-Labs/caracal/security/code-scanning/122)

Use strict validation on `service_id` so only expected service identifiers are accepted (for example, alphanumeric plus `_`/`-`). This is the safest minimal-change fix for this code because service IDs appear to be logical identifiers, not arbitrary nested paths. Reject invalid IDs early in `_load` by raising `KeyError`, preserving current behavior (`_dispatch` already translates `KeyError` into a 404).

**Best concrete fix in `examples/lynxCapital/_mock/server.py`:**
1. Add `import re`.
2. Add a compiled regex allowlist (e.g. `^[A-Za-z0-9_-]+$`).
3. In `_load`, before constructing `path`, validate `service_id` against this regex and raise `KeyError(service_id)` if invalid.

This prevents path traversal and keeps behavior/functionality consistent (unknown/invalid services return 404 as before).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
