### PR TITLE
Potential fix for code scanning alert no. 114: Clear-text storage of sensitive information

### DIFF
--- a/packages/caracal-server/caracal/deployment/config_manager.py
+++ b/packages/caracal-server/caracal/deployment/config_manager.py
@@ -1297,6 +1297,14 @@ class ConfigManager:
                     db_dump_path,
                 )
 
+                manifest_includes = {
+                    "workspace_files": True,
+                    "database_dump": db_dump_included,
+                }
+                # Only persist secret-related metadata when the archive is locked.
+                if normalized_lock_key:
+                    manifest_includes["secrets"] = include_secrets and bool(self._load_vault(name))
+
                 manifest = {
                     "format_version": 2,
                     "workspace": name,
@@ -1305,15 +1313,9 @@ class ConfigManager:
                         "locked": bool(normalized_lock_key),
                         "lock_format": "caracal-workspace-lock-v1" if normalized_lock_key else None,
                     },
-                    "includes": {
-                        "workspace_files": True,
-                        "secrets": include_secrets and bool(self._load_vault(name)),
-                        "database_dump": db_dump_included,
-                    },
+                    "includes": manifest_includes,
                 }
-                # Manifest contains only boolean flags and metadata — no secret values.
-                # The "secrets" key is a boolean indicating presence, not the secret itself.
-                (staged_workspace_dir / "export_manifest.json").write_text(  # lgtm[py/clear-text-storage-of-sensitive-data]
+                (staged_workspace_dir / "export_manifest.json").write_text(
                     json.dumps(manifest, indent=2)
                 )
 


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/114](https://github.com/Garudex-Labs/caracal/security/code-scanning/114)

General fix: ensure potentially sensitive export metadata is not written in clear text. For unencrypted exports, do not serialize secret-related indicators. For locked (encrypted) exports, retain full manifest metadata.

Best concrete fix here: in `packages/caracal-server/caracal/deployment/config_manager.py` inside `export_workspace`, build `manifest_includes` first, then conditionally remove `"secrets"` when `normalized_lock_key` is absent before writing `export_manifest.json`. This keeps existing export/import flow intact, preserves useful metadata, and prevents clear-text storage of secret-related state in unencrypted archives.

Changes needed:
- Edit only `export_workspace` manifest construction block around lines ~1300–1317.
- No new imports, dependencies, or new methods required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
