### PR TITLE
Potential fix for code scanning alert no. 121: Information exposure through an exception

### DIFF
--- a/examples/lynxCapital/app/api/setup.py
+++ b/examples/lynxCapital/app/api/setup.py
@@ -7,6 +7,7 @@ Setup state inspection endpoint for Caracal workspace validation.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 
@@ -14,6 +15,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _env() -> dict[str, str]:
@@ -140,7 +142,8 @@ def get_principals():
             raise ValueError("No principals found in database")
         return JSONResponse({"ok": True, "principals": principals})
     except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        logger.exception("Failed to fetch principals")
+        return JSONResponse({"ok": False, "error": "An internal error has occurred."}, status_code=500)
 
 
 @router.get("/tools")
@@ -149,7 +152,8 @@ def get_tools():
         tools = _query_db(_TOOLS_SQL)
         return JSONResponse({"ok": True, "tools": tools})
     except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        logger.exception("Failed to fetch tools")
+        return JSONResponse({"ok": False, "error": "An internal error has occurred."}, status_code=500)
 
 
 @router.get("/mandates")
@@ -158,4 +162,5 @@ def get_mandates():
         mandates = _query_db(_MANDATES_SQL)
         return JSONResponse({"ok": True, "mandates": mandates})
     except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        logger.exception("Failed to fetch mandates")
+        return JSONResponse({"ok": False, "error": "An internal error has occurred."}, status_code=500)


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/121](https://github.com/Garudex-Labs/caracal/security/code-scanning/121)

To fix this safely, return a generic error message to clients and log the actual exception server-side.  
Best minimal fix in `examples/lynxCapital/app/api/setup.py`:

- Add a module logger (`import logging`, `logger = logging.getLogger(__name__)`).
- In each `except Exception as exc:` block, replace `str(exc)` in response JSON with a constant generic message.
- Log exception details with `logger.exception(...)` so stack trace stays in server logs only.
- Keep status code and response structure (`{"ok": False, "error": ...}`) unchanged to avoid breaking clients.

This preserves functionality (error still reported, same HTTP 500 and shape) while removing sensitive leakage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
