### PR TITLE
Potential fix for code scanning alert no. 120: Information exposure through an exception

### DIFF
--- a/examples/lynxCapital/app/api/setup.py
+++ b/examples/lynxCapital/app/api/setup.py
@@ -7,6 +7,7 @@ Setup state inspection endpoint for Caracal workspace validation.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 
@@ -14,6 +15,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _env() -> dict[str, str]:
@@ -139,8 +141,9 @@ def get_principals():
         if not principals:
             raise ValueError("No principals found in database")
         return JSONResponse({"ok": True, "principals": principals})
-    except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+    except Exception:
+        logger.exception("Failed to fetch principals")
+        return JSONResponse({"ok": False, "error": "Internal server error"}, status_code=500)
 
 
 @router.get("/tools")
@@ -148,8 +151,9 @@ def get_tools():
     try:
         tools = _query_db(_TOOLS_SQL)
         return JSONResponse({"ok": True, "tools": tools})
-    except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+    except Exception:
+        logger.exception("Failed to fetch tools")
+        return JSONResponse({"ok": False, "error": "Internal server error"}, status_code=500)
 
 
 @router.get("/mandates")
@@ -157,5 +161,6 @@ def get_mandates():
     try:
         mandates = _query_db(_MANDATES_SQL)
         return JSONResponse({"ok": True, "mandates": mandates})
-    except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+    except Exception:
+        logger.exception("Failed to fetch mandates")
+        return JSONResponse({"ok": False, "error": "Internal server error"}, status_code=500)


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/120](https://github.com/Garudex-Labs/caracal/security/code-scanning/120)

To fix this without changing functionality, keep the same success behavior and HTTP status codes, but stop returning raw exception text in responses. Instead:

- Log exception details on the server (`logger.exception(...)`) so diagnostics are preserved.
- Return a generic error message to clients (for example, `"Internal server error"`).

In `examples/lynxCapital/app/api/setup.py`:
1. Add a standard-library logger import (`import logging`) near existing imports.
2. Define a module-level logger (for example, `logger = logging.getLogger(__name__)`) near `router = APIRouter()`.
3. Update each `except Exception as exc:` block in:
   - `get_principals` (lines ~142–143),
   - `get_tools` (lines ~151–152),
   - `get_mandates` (lines ~160–161),
   to log the exception and return a generic message instead of `str(exc)`.

No new third-party dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
