### PR TITLE
Potential fix for code scanning alert no. 119: Information exposure through an exception

### DIFF
--- a/examples/lynxCapital/app/api/setup.py
+++ b/examples/lynxCapital/app/api/setup.py
@@ -7,6 +7,7 @@ Setup state inspection endpoint for Caracal workspace validation.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 
@@ -14,6 +15,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _env() -> dict[str, str]:
@@ -140,7 +142,8 @@ def get_principals():
             raise ValueError("No principals found in database")
         return JSONResponse({"ok": True, "principals": principals})
     except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        logger.exception("Failed to fetch principals")
+        return JSONResponse({"ok": False, "error": "Internal server error"}, status_code=500)
 
 
 @router.get("/tools")
@@ -149,7 +152,8 @@ def get_tools():
         tools = _query_db(_TOOLS_SQL)
         return JSONResponse({"ok": True, "tools": tools})
     except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        logger.exception("Failed to fetch tools")
+        return JSONResponse({"ok": False, "error": "Internal server error"}, status_code=500)
 
 
 @router.get("/mandates")
@@ -158,4 +162,5 @@ def get_mandates():
         mandates = _query_db(_MANDATES_SQL)
         return JSONResponse({"ok": True, "mandates": mandates})
     except Exception as exc:
-        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+        logger.exception("Failed to fetch mandates")
+        return JSONResponse({"ok": False, "error": "Internal server error"}, status_code=500)


### PR DESCRIPTION
Potential fix for [https://github.com/Garudex-Labs/caracal/security/code-scanning/119](https://github.com/Garudex-Labs/caracal/security/code-scanning/119)

To fix this without changing endpoint behavior (status codes and success payloads), keep the `try/except` structure but stop returning raw exception text to clients. Instead:

- Add module-level logging (`import logging` + `logger = logging.getLogger(__name__)`).
- In each `except Exception as exc:` block, log the exception with stack trace server-side using `logger.exception(...)`.
- Return a generic error message in JSON (for example, `"Internal server error"`), preserving `{"ok": False, ...}` and `status_code=500`.

Apply this in `examples/lynxCapital/app/api/setup.py` at:
- imports section (add `logging`)
- near router setup (add logger definition)
- lines around each endpoint’s `except` return (lines 142–143, 151–152, 160–161 in the snippet)

No functional success-path changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
