### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -8,7 +8,6 @@ import {
   buildAdminClient,
   fail,
   flagBool,
-  flagString,
   parseArgs,
   printJSON,
   printTable,


### PR DESCRIPTION
To fix this without changing behavior, remove `flagString` from the named import list in `apps/cli/src/commands/agent.ts` if it is not used anywhere in that file. This is the safest and minimal change: it preserves runtime functionality and only cleans up an unnecessary symbol.

Concretely:
- Edit the import block at the top of `apps/cli/src/commands/agent.ts`.
- Delete `flagString,` from the `from './shared.ts'` import list.
- No new methods, definitions, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._