### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/typescript/unit/api/routes/policies.test.ts
+++ b/tests/typescript/unit/api/routes/policies.test.ts
@@ -3,7 +3,7 @@
 //
 // Policies route unit tests: Rego validation, version creation.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import Fastify from 'fastify'
 import { policiesRoutes } from '../../../../../apps/api/src/routes/policies.js'
 


### PR DESCRIPTION
The best fix is to remove only the unused `beforeEach` named import from the `vitest` import list in `tests/typescript/unit/api/routes/policies.test.ts`. This is a no-functional-change cleanup: it preserves all test behavior while resolving the CodeQL finding.

Specifically:
- Edit line 6 import statement.
- Keep `describe`, `it`, `expect`, and `vi`.
- Remove `beforeEach`.
- No additional methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._