### PR TITLE
docs: section hubs, branded 404, SEO, and inner-doc UX [3/3]

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,15 +7,25 @@
 
 import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
+import sitemap from '@astrojs/sitemap'
+
+const site = 'https://docs.garudexlabs.com'
+const ogImage = '/img/caracal.png'
+const description =
+  'Pre-execution authority enforcement for AI agents. Policies, mandates, and audit for production-grade autonomous systems.'
 
 export default defineConfig({
   output: 'static',
-  site: 'https://docs.garudexlabs.com',
+  site,
+  trailingSlash: 'always',
+  build: {
+    inlineStylesheets: 'auto',
+  },
   integrations: [
+    sitemap(),
     starlight({
       title: 'Caracal',
-      description:
-        'Pre-execution authority enforcement for AI agents. Policies, mandates, and audit for production-grade autonomous systems.',
+      description,
       logo: {
         light: './src/assets/caracal.png',
         dark: './src/assets/caracal_inverted.png',
@@ -31,6 +41,34 @@ export default defineConfig({
         {
           tag: 'link',
           attrs: { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
+        },
+        {
+          tag: 'meta',
+          attrs: { property: 'og:site_name', content: 'Caracal' },
+        },
+        {
+          tag: 'meta',
+          attrs: { property: 'og:type', content: 'website' },
+        },
+        {
+          tag: 'meta',
+          attrs: { property: 'og:image', content: `${site}${ogImage}` },
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'twitter:card', content: 'summary_large_image' },
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'twitter:image', content: `${site}${ogImage}` },
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'theme-color', content: '#0b0b0e' },
+        },
+        {
+          tag: 'meta',
+          attrs: { name: 'color-scheme', content: 'dark light' },
         },
       ],
       editLink: {
@@ -48,7 +86,8 @@ export default defineConfig({
         {
           label: 'Start',
           items: [
-            { label: 'Overview', link: '/start/overview/' },
+            { label: 'Overview', link: '/start/' },
+            { label: 'Introduction', link: '/start/overview/' },
             { label: 'Installation', link: '/start/installation/' },
             { label: 'Quickstart', link: '/start/quickstart/' },
           ],
@@ -57,6 +96,7 @@ export default defineConfig({
           label: 'Concepts',
           collapsed: false,
           items: [
+            { label: 'Overview', link: '/concepts/' },
             { label: 'Authority Enforcement Model', link: '/concepts/authority-enforcement/' },
             { label: 'Mandate', link: '/concepts/mandate/' },
             { label: 'Policy', link: '/concepts/policy/' },
@@ -72,6 +112,7 @@ export default defineConfig({
           label: 'Architecture',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/architecture/' },
             { label: 'System Overview', link: '/architecture/system/' },
             { label: 'Runtime Model', link: '/architecture/runtime/' },
             { label: 'Services', link: '/architecture/services/' },
@@ -83,7 +124,8 @@ export default defineConfig({
           label: 'CLI',
           collapsed: true,
           items: [
-            { label: 'Overview', link: '/cli/overview/' },
+            { label: 'Overview', link: '/cli/' },
+            { label: 'Commands', link: '/cli/overview/' },
             { label: 'caracal up / down / status', link: '/cli/stack/' },
             { label: 'caracal init', link: '/cli/init/' },
             { label: 'caracal run', link: '/cli/run/' },
@@ -95,6 +137,7 @@ export default defineConfig({
           label: 'Configuration',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/configuration/' },
             { label: 'Environment Variables', link: '/configuration/env/' },
             { label: 'Database', link: '/configuration/database/' },
             { label: 'Redis', link: '/configuration/redis/' },
@@ -106,6 +149,7 @@ export default defineConfig({
           label: 'AI Agents',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/ai/' },
             { label: 'Agent Workflows', link: '/ai/workflows/' },
             { label: 'MCP Integration', link: '/ai/mcp/' },
             { label: 'Coordinator', link: '/ai/coordinator/' },
@@ -115,6 +159,7 @@ export default defineConfig({
           label: 'SDKs',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/sdk/' },
             { label: 'TypeScript', link: '/sdk/typescript/' },
             { label: 'Python', link: '/sdk/python/' },
             { label: 'Go', link: '/sdk/go/' },
@@ -124,6 +169,7 @@ export default defineConfig({
           label: 'Security',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/security/' },
             { label: 'Threat Model', link: '/security/threat-model/' },
             { label: 'Disclosure Policy', link: '/security/disclosure/' },
             { label: 'Hardening', link: '/security/hardening/' },
@@ -133,6 +179,7 @@ export default defineConfig({
           label: 'Reference',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/reference/' },
             { label: 'API', link: '/reference/api/' },
             { label: 'Glossary', link: '/reference/glossary/' },
           ],
@@ -141,6 +188,7 @@ export default defineConfig({
           label: 'Contributing',
           collapsed: true,
           items: [
+            { label: 'Overview', link: '/contributing/' },
             { label: 'Setup', link: '/contributing/setup/' },
             { label: 'Workflow', link: '/contributing/workflow/' },
             { label: 'Code Style', link: '/contributing/style/' },

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/starlight": "0.38.4",
     "astro": "^6.2.1"
   }

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.garudexlabs.com/sitemap-index.xml

--- a/docs/src/components/SectionHub.astro
+++ b/docs/src/components/SectionHub.astro
@@ -1,0 +1,38 @@
+---
+/*
+ * Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+ * Caracal, a product of Garudex Labs
+ *
+ * SectionHub: reusable in-docs grid of cards used by section landing pages
+ * to give every top-level navigation node a polished, scannable overview.
+ */
+
+interface Item {
+  title: string
+  href: string
+  description?: string
+  meta?: string
+}
+
+interface Props {
+  items: Item[]
+  columns?: number
+}
+
+const { items, columns = 2 } = Astro.props as Props
+---
+
+<div class={`section-hub section-hub--cols-${columns}`}>
+  {items.map((item) => (
+    <a class="section-hub__card" href={item.href}>
+      <div class="section-hub__card-head">
+        <h3 class="section-hub__card-title">{item.title}</h3>
+        {item.meta && <span class="section-hub__card-meta">{item.meta}</span>}
+      </div>
+      {item.description && (
+        <p class="section-hub__card-body">{item.description}</p>
+      )}
+      <span class="section-hub__card-cta" aria-hidden="true">Read →</span>
+    </a>
+  ))}
+</div>

--- a/docs/src/content/docs/404.mdx
+++ b/docs/src/content/docs/404.mdx
@@ -1,0 +1,26 @@
+---
+title: Page not found
+description: We couldn't find what you were looking for in the Caracal docs.
+template: splash
+editUrl: false
+---
+
+import LandingFooter from '../../components/LandingFooter.astro'
+
+<div class="notfound">
+  <div class="notfound__inner">
+    <p class="notfound__eyebrow">Error · 404</p>
+    <h1 class="notfound__title">This path is unenforced.</h1>
+    <p class="notfound__lede">
+      The page you tried to open does not exist — or it has moved as part of
+      the ongoing documentation rewrite. Try the entry points below or use the
+      site search.
+    </p>
+    <div class="notfound__actions">
+      <a class="landing-button landing-button--primary" href="/">Go to home page</a>
+      <a class="landing-button landing-button--secondary" href="/#contact">Report broken page</a>
+    </div>
+  </div>
+</div>
+
+<LandingFooter />

--- a/docs/src/content/docs/ai/index.mdx
+++ b/docs/src/content/docs/ai/index.mdx
@@ -1,0 +1,18 @@
+---
+title: AI Agents
+description: Patterns for building AI agents and multi-agent workflows that run under Caracal's enforced authority.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Caracal is designed agent-first. This section covers workflows, MCP, and the coordinator runtime.
+
+<SectionHub
+  items={[
+    { title: 'Agent Workflows', href: '/ai/workflows/', description: 'Patterns for single-agent and multi-agent runs under enforced policy.' },
+    { title: 'MCP Integration', href: '/ai/mcp/', description: 'Front an MCP server with Caracal so every tool call is policy-checked.' },
+    { title: 'Coordinator', href: '/ai/coordinator/', description: 'Route agent traffic, delegate authority, and observe runs end-to-end.' },
+  ]}
+/>

--- a/docs/src/content/docs/architecture/index.mdx
+++ b/docs/src/content/docs/architecture/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Architecture
+description: How Caracal is built — system layers, runtime model, services, storage, and threat surface.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+The internals of the Caracal control plane and gate, written for platform and security engineers.
+
+<SectionHub
+  items={[
+    { title: 'System Overview', href: '/architecture/system/', description: 'The complete picture: control plane, gate, SDKs, and data flow.' },
+    { title: 'Runtime Model', href: '/architecture/runtime/', description: 'How requests, mandates, and decisions move through the runtime.' },
+    { title: 'Services', href: '/architecture/services/', description: 'API, coordinator, audit, gateway, STS — what each service owns.' },
+    { title: 'Storage & Data', href: '/architecture/storage/', description: 'Postgres, Redis streams, and the ledger model.' },
+    { title: 'Threat Model', href: '/architecture/threat-model/', description: 'Trust boundaries, adversary classes, and mitigations.' },
+  ]}
+/>

--- a/docs/src/content/docs/cli/index.mdx
+++ b/docs/src/content/docs/cli/index.mdx
@@ -1,0 +1,21 @@
+---
+title: CLI
+description: The caracal command-line interface — install, run, inspect, audit, and manage delegated agents.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Everything `caracal` can do from the terminal — for both operators and developers.
+
+<SectionHub
+  items={[
+    { title: 'Commands', href: '/cli/overview/', description: 'The full command surface and global flags.' },
+    { title: 'Stack lifecycle', href: '/cli/stack/', description: '`caracal up`, `down`, and `status` for the local runtime.' },
+    { title: 'caracal init', href: '/cli/init/', description: 'Bootstrap a new workspace with sensible defaults.' },
+    { title: 'caracal run', href: '/cli/run/', description: 'Execute an agent under an enforced mandate.' },
+    { title: 'audit & explain', href: '/cli/audit/', description: 'Inspect decisions, replay runs, and explain denials.' },
+    { title: 'agent & delegation', href: '/cli/agent/', description: 'Manage agents and pass scoped authority between principals.' },
+  ]}
+/>

--- a/docs/src/content/docs/concepts/index.mdx
+++ b/docs/src/content/docs/concepts/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Concepts
+description: The primitives behind pre-execution authority enforcement — mandates, policies, principals, delegation, caveats, intent, workspace, and ledger.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+The vocabulary every operator, developer, and security engineer should share before reaching the architecture or SDK chapters.
+
+<SectionHub
+  columns={3}
+  items={[
+    { title: 'Authority Enforcement', href: '/concepts/authority-enforcement/', description: 'The model Caracal implements: bind agents to policy before code runs.' },
+    { title: 'Mandate', href: '/concepts/mandate/', description: 'Short-lived, signed authority objects scoped to principal, policy, and intent.' },
+    { title: 'Policy', href: '/concepts/policy/', description: 'Declarative rules evaluated at the gate — permit, deny, or constrain.' },
+    { title: 'Principal', href: '/concepts/principal/', description: 'The identity (human, service, or agent) acting under a mandate.' },
+    { title: 'Delegation', href: '/concepts/delegation/', description: 'Pass scoped authority safely from one principal to another.' },
+    { title: 'Caveat', href: '/concepts/caveat/', description: 'Narrowing conditions attached to mandates to shrink blast radius.' },
+    { title: 'Intent', href: '/concepts/intent/', description: 'The declared operation an agent is about to perform.' },
+    { title: 'Workspace', href: '/concepts/workspace/', description: 'Boundary for policies, principals, and audit data.' },
+    { title: 'Ledger', href: '/concepts/ledger/', description: 'Append-only record of every decision — replay, prove, revoke.' },
+  ]}
+/>

--- a/docs/src/content/docs/configuration/index.mdx
+++ b/docs/src/content/docs/configuration/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Configuration
+description: Configure the Caracal runtime — environment variables, database, Redis, logging, and the MCP adapter.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Every knob you can turn on a Caracal deployment, with safe defaults documented alongside.
+
+<SectionHub
+  items={[
+    { title: 'Environment Variables', href: '/configuration/env/', description: 'The complete environment surface, grouped by service.' },
+    { title: 'Database', href: '/configuration/database/', description: 'Postgres connection, migrations, and tuning.' },
+    { title: 'Redis', href: '/configuration/redis/', description: 'Streams, retention, and cache configuration.' },
+    { title: 'Logging', href: '/configuration/logging/', description: 'Structured logs, levels, and forwarding.' },
+    { title: 'MCP Adapter', href: '/configuration/mcp/', description: 'Wire Caracal into MCP-speaking agents and tools.' },
+  ]}
+/>

--- a/docs/src/content/docs/contributing/index.mdx
+++ b/docs/src/content/docs/contributing/index.mdx
@@ -1,0 +1,18 @@
+---
+title: Contributing
+description: How to set up the Caracal monorepo, ship changes, and match the project's code style.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Caracal is built in the open. Here is how to participate.
+
+<SectionHub
+  items={[
+    { title: 'Setup', href: '/contributing/setup/', description: 'Clone the monorepo and get the full stack running locally.' },
+    { title: 'Workflow', href: '/contributing/workflow/', description: 'Branching, commits, pull requests, and review expectations.' },
+    { title: 'Code Style', href: '/contributing/style/', description: 'Conventions enforced across Go, TypeScript, and Python.' },
+  ]}
+/>

--- a/docs/src/content/docs/reference/index.mdx
+++ b/docs/src/content/docs/reference/index.mdx
@@ -1,0 +1,17 @@
+---
+title: Reference
+description: API surface, glossary, and other reference material for the Caracal platform.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Lookup material — read it when you need it, search it when you don't.
+
+<SectionHub
+  items={[
+    { title: 'API', href: '/reference/api/', description: 'HTTP and gRPC API surface for the runtime services.' },
+    { title: 'Glossary', href: '/reference/glossary/', description: 'Every Caracal term in one place, cross-linked to concepts.' },
+  ]}
+/>

--- a/docs/src/content/docs/sdk/index.mdx
+++ b/docs/src/content/docs/sdk/index.mdx
@@ -1,0 +1,19 @@
+---
+title: SDKs
+description: Build Caracal-aware applications and agents in TypeScript, Python, or Go.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Official SDKs that issue mandates, wrap tool calls, and stream audit events into your application code.
+
+<SectionHub
+  columns={3}
+  items={[
+    { title: 'TypeScript', href: '/sdk/typescript/', description: 'For Node, edge runtimes, and browser-facing agents.' },
+    { title: 'Python', href: '/sdk/python/', description: 'For LangChain, CrewAI, and FastMCP-based agents.' },
+    { title: 'Go', href: '/sdk/go/', description: 'For systems agents and high-throughput services.' },
+  ]}
+/>

--- a/docs/src/content/docs/security/index.mdx
+++ b/docs/src/content/docs/security/index.mdx
@@ -1,0 +1,18 @@
+---
+title: Security
+description: Caracal's threat model, disclosure policy, and production hardening guidance.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+Security is the product. This section documents the threat surface, the disclosure process, and how to deploy Caracal safely.
+
+<SectionHub
+  items={[
+    { title: 'Threat Model', href: '/security/threat-model/', description: 'Trust boundaries, adversary classes, and mitigations.' },
+    { title: 'Disclosure Policy', href: '/security/disclosure/', description: 'How to report vulnerabilities responsibly.' },
+    { title: 'Hardening', href: '/security/hardening/', description: 'Production checklist for hardened Caracal deployments.' },
+  ]}
+/>

--- a/docs/src/content/docs/start/index.mdx
+++ b/docs/src/content/docs/start/index.mdx
@@ -1,0 +1,33 @@
+---
+title: Start
+description: Get Caracal running locally and route your first AI agent action through pre-execution authority.
+---
+
+import SectionHub from '../../../components/SectionHub.astro'
+
+> **Documentation in progress.** This section is being filled in as the open-source rewrite lands.
+
+The fastest path from zero to a Caracal-enforced agent.
+
+<SectionHub
+  items={[
+    {
+      title: 'Introduction',
+      href: '/start/overview/',
+      description: 'What Caracal is, why it exists, and where it fits in your stack.',
+      meta: 'Read first',
+    },
+    {
+      title: 'Installation',
+      href: '/start/installation/',
+      description: 'Install the CLI, bring up the runtime, and verify your local stack.',
+      meta: 'Setup',
+    },
+    {
+      title: 'Quickstart',
+      href: '/start/quickstart/',
+      description: 'Issue your first mandate and run an agent under enforced policy.',
+      meta: 'Hands-on',
+    },
+  ]}
+/>

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -158,7 +158,14 @@ header.header {
   background: color-mix(in srgb, var(--sl-color-bg) 88%, transparent);
   backdrop-filter: saturate(160%) blur(10px);
   -webkit-backdrop-filter: saturate(160%) blur(10px);
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: var(--sl-z-index-navbar, 50);
+}
+
+.page > header.header {
+  position: sticky;
+  top: 0;
 }
 
 header.header > div.header > div:nth-child(2) {
@@ -203,6 +210,40 @@ nav.sidebar {
 
 .content-panel + .content-panel {
   border-top: 1px solid var(--sl-color-hairline);
+}
+
+.main-frame:not(:has(.landing-hero)) {
+  padding-top: 1.25rem;
+}
+
+.main-frame:not(:has(.landing-hero)) .content-panel:first-of-type {
+  padding-block: 1rem;
+}
+
+.main-frame:not(:has(.landing-hero)) .content-panel:first-of-type h1 {
+  margin-top: 0;
+}
+
+/* Mobile "On this page" dropdown — give it room below the sticky header */
+mobile-starlight-toc {
+  display: block;
+}
+
+mobile-starlight-toc nav {
+  position: sticky;
+  top: var(--sl-nav-height, 3.75rem);
+  z-index: 40;
+  background: color-mix(in srgb, var(--sl-color-bg) 92%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--sl-color-hairline);
+}
+
+/* On viewports where the mobile TOC is visible, push first content down */
+@media (max-width: 72rem) {
+  .main-frame:not(:has(.landing-hero)) .content-panel:first-of-type {
+    padding-top: 1.5rem;
+  }
 }
 
 .sl-markdown-content :is(code):not(pre code) {
@@ -1539,4 +1580,228 @@ select,
 .what-is__card,
 .audience__card {
   cursor: var(--caracal-cursor-pointer);
+}
+
+/* ───────────────────────── Inner docs reading UX ───────────────────────── */
+
+/* TOC + meta refinements */
+.right-sidebar h2,
+.right-sidebar .sl-heading-text {
+  font-family: "Space Grotesk", var(--sl-font);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: var(--sl-color-gray-4);
+}
+
+.right-sidebar a[aria-current="true"] {
+  color: var(--sl-color-text-accent);
+  border-left-color: var(--caracal-link);
+}
+
+footer .meta,
+footer.meta {
+  font-size: 0.85rem;
+  color: var(--sl-color-gray-3);
+}
+
+footer .meta a {
+  color: var(--sl-color-text-accent);
+}
+
+/* Pagination links — compact text style */
+.pagination-links a .link-title {
+  font-family: "Space Grotesk", var(--sl-font);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.pagination-links a > span {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sl-color-gray-4);
+}
+
+.pagination-links a:hover .link-title {
+  color: var(--caracal-link);
+}
+
+/* Inline placeholder callout (used on stub pages) */
+.sl-markdown-content blockquote:first-child {
+  margin-block: 1rem 1.5rem;
+}
+
+/* ─────────────────────── SectionHub (in-docs) ─────────────────────── */
+
+.section-hub {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.section-hub--cols-3 {
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.section-hub__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.1rem 1.15rem 1.2rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 10px;
+  background: var(--caracal-panel);
+  color: var(--sl-color-text);
+  text-decoration: none;
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.section-hub__card:hover {
+  border-color: color-mix(in srgb, var(--caracal-link) 50%, var(--sl-color-hairline));
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px -18px color-mix(in srgb, var(--caracal-link) 35%, transparent);
+}
+
+.section-hub__card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.section-hub__card-title {
+  margin: 0;
+  font-family: "Space Grotesk", var(--sl-font);
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--sl-color-text);
+}
+
+.section-hub__card-meta {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--caracal-link);
+  padding: 0.15rem 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--caracal-link) 35%, transparent);
+  border-radius: 999px;
+}
+
+.section-hub__card-body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--sl-color-gray-3);
+}
+
+.section-hub__card-cta {
+  margin-top: auto;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--caracal-link);
+}
+
+/* ─────────────────────────── 404 layout ─────────────────────────── */
+
+.main-frame:has(.notfound) {
+  padding-top: 0 !important;
+}
+
+.main-pane:has(.notfound),
+.main-pane:has(.notfound) .main-frame,
+.content-panel:has(.notfound) {
+  max-width: none !important;
+  width: 100% !important;
+}
+
+.main-frame:has(.notfound) .content-panel {
+  padding: 0 !important;
+  border: 0 !important;
+  margin: 0 !important;
+}
+
+.main-frame:has(.notfound) .sl-container {
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.main-frame:has(.notfound) .sl-container > h1#_top {
+  display: none;
+}
+
+.notfound {
+  width: 100%;
+  min-height: calc(100vh - 6rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(3rem, 8vh, 6rem) clamp(1rem, 4vw, 3rem);
+  position: relative;
+  isolation: isolate;
+}
+
+.notfound::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(
+      circle at center,
+      color-mix(in srgb, var(--caracal-link) 25%, transparent) 0%,
+      transparent 60%
+    );
+  filter: blur(60px);
+  opacity: 0.5;
+}
+
+.notfound__inner {
+  max-width: 42rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.notfound__eyebrow {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--caracal-link);
+  font-family: var(--sl-font-mono);
+}
+
+.notfound__title {
+  margin: 0;
+  font-family: "Space Grotesk", var(--sl-font);
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--sl-color-text);
+}
+
+.notfound__lede {
+  margin: 0;
+  max-width: 32rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--sl-color-text) 72%, transparent);
+}
+
+.notfound__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+  margin-top: 0.75rem;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
 
   docs:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.2
+        version: 3.7.2
       '@astrojs/starlight':
         specifier: 0.38.4
         version: 0.38.4(astro@6.2.1(@types/node@24.12.2)(ioredis@5.10.1)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))


### PR DESCRIPTION
## PR Title

docs: section hubs, branded 404, SEO, and inner-doc UX [3/3]


## Summary

Final patch in the Starlight docs platform series. Adds sitemap + SEO/OG metadata, a branded 404 page, a reusable SectionHub component with overview pages for every top-level section, sidebar Overview entries, and inner-doc UX polish (sticky header, tightened top spacing, sticky mobile TOC, refined pagination).


## Related Issue

Closes #134


## Type of Change

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [x] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes:
- `pnpm build` green — 54 pages, `sitemap-index.xml` + `sitemap-0.xml` generated, Pagefind search index built, `dist/404.html` present.
- `pnpm preview` verified: navigation hubs, 404 page (home + report buttons), sticky header, mobile TOC, and section landing pages all render correctly across light/dark themes.


## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed


## Screenshots / Demos (if UI or UX)

<!-- Attach screenshots of a section hub page, the 404 page, and the mobile TOC behavior. -->


## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed