### PR TITLE
Add onlyBuiltDependencies configuration for PNPM in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "version": "changeset version",
     "release": "pnpm run build:typescript && changeset publish"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild", "sharp"]
+  },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",
     "@vitest/coverage-v8": "3.2.4",


### PR DESCRIPTION
This pull request makes a configuration update to the `package.json` file to optimize dependency installation with pnpm. Specifically, it ensures that only the necessary built dependencies are included during the install process.

- Dependency management:
  * Added a `pnpm.onlyBuiltDependencies` field to `package.json` to specify that only `esbuild` and `sharp` should be treated as built dependencies by pnpm.