### PR TITLE
fix: bootstrap TypeScript workspace builds in workspace shims

### DIFF
--- a/apps/cli/bin/caracal-workspace.mjs
+++ b/apps/cli/bin/caracal-workspace.mjs
@@ -32,16 +32,17 @@ if (!root) {
 
 process.env.CARACAL_REPO_ROOT = root
 
-const engineDist = join(root, 'packages/engine/dist/index.js')
-if (!existsSync(engineDist)) {
-  process.stderr.write('caracal: building @caracalai/engine (first run)…\n')
+const tsBuilds = [
+  'packages/core/ts/dist/index.js',
+  'packages/admin/ts/dist/index.js',
+  'packages/engine/dist/index.js',
+]
+if (tsBuilds.some((path) => !existsSync(join(root, path)))) {
+  process.stderr.write('caracal: building TypeScript workspace packages (first run)…\n')
   try {
-    execFileSync('pnpm', ['--filter', '@caracalai/engine', 'build'], {
-      cwd: root,
-      stdio: 'inherit',
-    })
+    execFileSync('pnpm', ['run', 'build:typescript'], { cwd: root, stdio: 'inherit' })
   } catch (err) {
-    process.stderr.write(`caracal: failed to build engine: ${err?.message ?? err}\n`)
+    process.stderr.write(`caracal: failed to build TypeScript workspace packages: ${err?.message ?? err}\n`)
     process.exit(1)
   }
 }

--- a/apps/tui/bin/caracal-tui-workspace.mjs
+++ b/apps/tui/bin/caracal-tui-workspace.mjs
@@ -32,16 +32,17 @@ if (!root) {
 
 process.env.CARACAL_REPO_ROOT = root
 
-const engineDist = join(root, 'packages/engine/dist/index.js')
-if (!existsSync(engineDist)) {
-  process.stderr.write('caracal-tui: building @caracalai/engine (first run)…\n')
+const tsBuilds = [
+  'packages/core/ts/dist/index.js',
+  'packages/admin/ts/dist/index.js',
+  'packages/engine/dist/index.js',
+]
+if (tsBuilds.some((path) => !existsSync(join(root, path)))) {
+  process.stderr.write('caracal-tui: building TypeScript workspace packages (first run)…\n')
   try {
-    execFileSync('pnpm', ['--filter', '@caracalai/engine', 'build'], {
-      cwd: root,
-      stdio: 'inherit',
-    })
+    execFileSync('pnpm', ['run', 'build:typescript'], { cwd: root, stdio: 'inherit' })
   } catch (err) {
-    process.stderr.write(`caracal-tui: failed to build engine: ${err?.message ?? err}\n`)
+    process.stderr.write(`caracal-tui: failed to build TypeScript workspace packages: ${err?.message ?? err}\n`)
     process.exit(1)
   }
 }


### PR DESCRIPTION
This PR fixes a first-run crash in workspace mode where CLI/TUI startup could fail with missing module errors when package dist outputs were not built yet.
The workspace shims now verify required TypeScript build artifacts and run the existing workspace TypeScript build pipeline when any are missing.
This makes local startup deterministic for fresh clones and clean workspaces.

Related Issue
Fixes #___

Type of Change: FIX 
How Was This Tested? : Local RUN 


Notes:
Ran node caracal-workspace.mjs --help.
Verified startup no longer crashes with missing @caracalai/core / @caracalai/admin dist imports.
Confirmed CLI help output is shown successfully.

CE & Security Check:
Targets Caracal OpenSource only (no EE code)
No secrets or credentials committed

Screenshots / Demos (if UI or UX)
N/A (no UI changes)

Checklist
 Code follows project style
 Self-reviewed
