### PR TITLE
docs: fix contributor sanity checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ scripts/testCi.sh --smoke | --go | --py | --ts
   - `pnpm caracal up`
   - `pnpm caracal status`
   - `pnpm caracal console`
-  - `pnpm caracal console`
+  - `pnpm caracal down`
 4. Ensure tests pass:
   - `pnpm test`
   - `scripts/testCi.sh --smoke` (post-commit parity)


### PR DESCRIPTION
﻿## Summary
- replace the duplicate `pnpm caracal console` sanity-check step with `pnpm caracal down`
- keeps the contributor quick-check flow ending with stack cleanup

## Test plan
- `git diff --check`
- `corepack pnpm exec prettier --check CONTRIBUTING.md` *(blocked: repository dependencies are not installed in this checkout, so `prettier` is unavailable)*
