### PR TITLE
fix(crypto): skip nil values in Go CanonicalizeStream to match TS

### DIFF
--- a/packages/core/go/crypto/streamsig.go
+++ b/packages/core/go/crypto/streamsig.go
@@ -20,7 +20,7 @@ const StreamSigField = "_sig"
 
 // CanonicalizeStream produces a deterministic byte serialization of a stream values
 // map for signing. Keys are sorted; values are coerced to strings via Sprint, the same
-// shape Redis preserves on the wire. The reserved sig field is skipped.
+// shape Redis preserves on the wire. Nil values and the reserved sig field are skipped.
 func CanonicalizeStream(stream string, values map[string]any) []byte {
 	keys := make([]string, 0, len(values))
 	for k := range values {

--- a/packages/core/go/crypto/streamsig.go
+++ b/packages/core/go/crypto/streamsig.go
@@ -34,6 +34,9 @@ func CanonicalizeStream(stream string, values map[string]any) []byte {
 	b.WriteString(stream)
 	b.WriteByte('\n')
 	for _, k := range keys {
+		if values[k] == nil {
+			continue
+		}
 		b.WriteString(k)
 		b.WriteByte('=')
 		b.WriteString(fmt.Sprint(values[k]))

--- a/tests/go/contract/interoperability/contracts_test.go
+++ b/tests/go/contract/interoperability/contracts_test.go
@@ -6,12 +6,15 @@
 package interoperability_test
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/garudex-labs/caracal/packages/core/go/crypto"
 )
 
 type jwtClaims struct {
@@ -115,3 +118,35 @@ func TestAgentConnectorManifestLabelsEnforcement(t *testing.T) {
 		t.Fatalf("agent connectors must label enforcement mode: %#v", manifest["audit"])
 	}
 }
+
+func TestStreamSigCanonicalizeVectors(t *testing.T) {
+	type vector struct {
+		Description       string         `json:"description"`
+		Stream            string         `json:"stream"`
+		Values            map[string]any `json:"values"`
+		ExpectedCanonical string         `json:"expected_canonical"`
+		HmacKeyHex        string         `json:"hmac_key_hex"`
+		ExpectedSigHex    string         `json:"expected_sig_hex"`
+	}
+
+	vectors := readFixture[[]vector](t, "stream-sig-canonicalize.vectors.json")
+
+	for _, v := range vectors {
+		t.Run(v.Description, func(t *testing.T) {
+			got := string(crypto.CanonicalizeStream(v.Stream, v.Values))
+			if got != v.ExpectedCanonical {
+				t.Fatalf("canonical mismatch:\ngot:  %q\nwant: %q", got, v.ExpectedCanonical)
+			}
+
+			key, err := hex.DecodeString(v.HmacKeyHex)
+			if err != nil {
+				t.Fatalf("bad hmac key hex: %v", err)
+			}
+			sig := crypto.SignStream(key, v.Stream, v.Values)
+			if sig != v.ExpectedSigHex {
+				t.Fatalf("sig mismatch:\ngot:  %s\nwant: %s", sig, v.ExpectedSigHex)
+			}
+		})
+	}
+}
+

--- a/tests/go/unit/shared/crypto/crypto_test.go
+++ b/tests/go/unit/shared/crypto/crypto_test.go
@@ -44,3 +44,60 @@ func TestGenerateP256Key(t *testing.T) {
 		t.Fatalf("generated key is incomplete: %#v", key)
 	}
 }
+
+func TestCanonicalizeStreamSkipsNilValues(t *testing.T) {
+	got := string(CanonicalizeStream("s", map[string]any{
+		"action":   "transfer",
+		"metadata": nil,
+	}))
+	want := "s\naction=transfer\n"
+	if got != want {
+		t.Fatalf("nil value not skipped:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestCanonicalizeStreamSkipsSigField(t *testing.T) {
+	got := string(CanonicalizeStream("s", map[string]any{
+		"action": "transfer",
+		"_sig":   "deadbeef",
+	}))
+	want := "s\naction=transfer\n"
+	if got != want {
+		t.Fatalf("_sig field not excluded:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestCanonicalizeStreamDeterministicOrder(t *testing.T) {
+	values := map[string]any{"z": "1", "a": "2", "m": "3"}
+	want := "s\na=2\nm=3\nz=1\n"
+	// Run multiple times to catch map-ordering flakiness.
+	for i := 0; i < 50; i++ {
+		if got := string(CanonicalizeStream("s", values)); got != want {
+			t.Fatalf("iteration %d: key order unstable:\ngot:  %q\nwant: %q", i, got, want)
+		}
+	}
+}
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	key := []byte("00112233445566778899aabbccddeeff")
+	values := map[string]any{"action": "transfer", "amount": "100"}
+	sig := SignStream(key, "s", values)
+	if sig == "" {
+		t.Fatal("SignStream returned empty signature")
+	}
+	values[StreamSigField] = sig
+	if !VerifyStream(key, "s", values) {
+		t.Fatal("VerifyStream rejected its own signature")
+	}
+}
+
+func TestSignVerifyWithNilField(t *testing.T) {
+	key := []byte("00112233445566778899aabbccddeeff")
+	values := map[string]any{"action": "transfer", "metadata": nil}
+	sig := SignStream(key, "s", values)
+	values[StreamSigField] = sig
+	if !VerifyStream(key, "s", values) {
+		t.Fatal("VerifyStream rejected signature for payload with nil field")
+	}
+}
+

--- a/tests/shared/fixtures/interoperability/stream-sig-canonicalize.vectors.json
+++ b/tests/shared/fixtures/interoperability/stream-sig-canonicalize.vectors.json
@@ -1,0 +1,34 @@
+[
+  {
+    "description": "basic fields, no nulls",
+    "stream": "audit:events",
+    "values": { "action": "transfer", "amount": "100" },
+    "expected_canonical": "audit:events\naction=transfer\namount=100\n",
+    "hmac_key_hex": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "expected_sig_hex": "c06ccc579e026c31a97a04f203981b236a3c88041712e9b46242e8762da23d75"
+  },
+  {
+    "description": "null field must be skipped",
+    "stream": "audit:events",
+    "values": { "action": "transfer", "metadata": null },
+    "expected_canonical": "audit:events\naction=transfer\n",
+    "hmac_key_hex": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "expected_sig_hex": "93c82e377fc1ff7f1430549aa20cd20971150173b5996308ab84cb48d6f2683d"
+  },
+  {
+    "description": "_sig field excluded from canonical form",
+    "stream": "audit:events",
+    "values": { "action": "transfer", "_sig": "deadbeef" },
+    "expected_canonical": "audit:events\naction=transfer\n",
+    "hmac_key_hex": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "expected_sig_hex": "93c82e377fc1ff7f1430549aa20cd20971150173b5996308ab84cb48d6f2683d"
+  },
+  {
+    "description": "boolean and numeric values serialize correctly",
+    "stream": "audit:events",
+    "values": { "active": "true", "count": "0", "name": "" },
+    "expected_canonical": "audit:events\nactive=true\ncount=0\nname=\n",
+    "hmac_key_hex": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "expected_sig_hex": "dd36b85d880107b52155410569f95436acd8b5a656bba83e37c4b0196fb32ae1"
+  }
+]

--- a/tests/shared/fixtures/interoperability/stream-sig-canonicalize.vectors.json
+++ b/tests/shared/fixtures/interoperability/stream-sig-canonicalize.vectors.json
@@ -24,7 +24,7 @@
     "expected_sig_hex": "93c82e377fc1ff7f1430549aa20cd20971150173b5996308ab84cb48d6f2683d"
   },
   {
-    "description": "boolean and numeric values serialize correctly",
+    "description": "string values (including empty) serialize correctly",
     "stream": "audit:events",
     "values": { "active": "true", "count": "0", "name": "" },
     "expected_canonical": "audit:events\nactive=true\ncount=0\nname=\n",

--- a/tests/typescript/contract/interoperability/schemas.test.ts
+++ b/tests/typescript/contract/interoperability/schemas.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { signStream } from '@caracalai/core'
 
 type Json = null | boolean | number | string | Json[] | { [key: string]: Json }
 type Schema = {
@@ -172,4 +173,28 @@ describe('public interoperability schemas', () => {
       baggage: expect.stringContaining('caracal.agent_session='),
     })
   })
+})
+
+describe('stream-sig canonicalization vectors', () => {
+  interface Vector {
+    description: string
+    stream: string
+    values: Record<string, string | null>
+    expected_canonical: string
+    hmac_key_hex: string
+    expected_sig_hex: string
+  }
+
+  const vectors = JSON.parse(
+    readFileSync(resolve(fixtureDir, 'stream-sig-canonicalize.vectors.json'), 'utf8'),
+  ) as Vector[]
+
+  it.each(vectors.map((v) => [v.description, v] as const))(
+    '%s',
+    (_desc, vector) => {
+      const key = Buffer.from(vector.hmac_key_hex, 'hex')
+      const sig = signStream(key, vector.stream, vector.values)
+      expect(sig).toBe(vector.expected_sig_hex)
+    },
+  )
 })


### PR DESCRIPTION
## PR Title

fix(crypto): skip nil values in Go CanonicalizeStream to match TS

## Summary

Go's `CanonicalizeStream` rendered `nil` map values as the literal string `"<nil>"` via `fmt.Sprint()`, while TypeScript's `canonicalizeStream` skips `null`/`undefined` entirely. This produced divergent HMAC-SHA256 signatures for the same payload, breaking cross-language `VerifyStream` in mixed Go/TS deployments. Added a nil guard in Go to skip nil entries, matching TypeScript behavior, along with unit tests and shared cross-language contract test vectors.

## Related Issue

<!-- One of: Fixes / Resolves / Closes -->
Fixes #187 


## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [x] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [x] Local run
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested (explain why)

Notes:
- **Go unit tests** (5 new): `TestCanonicalizeStreamSkipsNilValues`, `TestCanonicalizeStreamSkipsSigField`, `TestCanonicalizeStreamDeterministicOrder`, `TestSignVerifyRoundTrip`, `TestSignVerifyWithNilField` : all pass
- **Go contract tests**: `TestStreamSigCanonicalizeVectors` reads shared golden fixture, asserts canonical form + HMAC for 4 vectors : all pass
- **TS contract tests**: `stream-sig canonicalization vectors` reads same fixture, asserts `signStream` output matches golden HMACs : all 103 tests pass (including 4 new)


## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed


## Screenshots / Demos (if UI or UX)

N/A  (backend crypto fix, no UI changes.)

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed
