### PR TITLE
fix: make workspace shims portable on Windows

### DIFF
--- a/apps/console/bin/caracal-console-workspace.mjs
+++ b/apps/console/bin/caracal-console-workspace.mjs
@@ -4,9 +4,10 @@
 //
 // Workspace entry: locates the repo root, stamps a dev Console identity, then delegates to the workspace Console.
 
-import { execFileSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { existsSync, readdirSync, statSync } from 'fs'
 import { dirname, join } from 'path'
+import { pathToFileURL } from 'url'
 
 function findRepoRoot(start) {
   let dir = start
@@ -68,7 +69,7 @@ const staleBuilds = [
 if (tsBuilds.some((path) => !existsSync(join(root, path))) || staleBuilds.some(([source, output]) => sourceIsNewer(source, output))) {
   process.stderr.write('caracal-console: building TypeScript workspace packages…\n')
   try {
-    execFileSync('pnpm', ['run', 'build:typescript'], { cwd: root, stdio: 'inherit' })
+    execSync('pnpm run build:typescript', { cwd: root, stdio: 'inherit' })
   } catch (err) {
     process.stderr.write(`caracal-console: failed to build TypeScript workspace packages: ${err?.message ?? err}\n`)
     process.exit(1)
@@ -87,7 +88,7 @@ try {
   process.exit(1)
 }
 
-import(join(root, 'apps/console/bin/caracal-console.mjs')).catch((err) => {
+import(pathToFileURL(join(root, 'apps/console/bin/caracal-console.mjs')).href).catch((err) => {
   process.stderr.write(`caracal-console: ${err?.message ?? err}\n`)
   process.exit(1)
 })

--- a/apps/runtime/bin/caracal-workspace.mjs
+++ b/apps/runtime/bin/caracal-workspace.mjs
@@ -4,9 +4,10 @@
 //
 // Workspace entry: locates the repo root, stamps a dev runtime identity, then delegates to the workspace shell.
 
-import { execFileSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { existsSync, readdirSync, statSync } from 'fs'
 import { dirname, join } from 'path'
+import { pathToFileURL } from 'url'
 
 function findRepoRoot(start) {
   let dir = start
@@ -68,7 +69,7 @@ const staleBuilds = [
 if (tsBuilds.some((path) => !existsSync(join(root, path))) || staleBuilds.some(([source, output]) => sourceIsNewer(source, output))) {
   process.stderr.write('caracal: building TypeScript workspace packages…\n')
   try {
-    execFileSync('pnpm', ['run', 'build:typescript'], { cwd: root, stdio: 'inherit' })
+    execSync('pnpm run build:typescript', { cwd: root, stdio: 'inherit' })
   } catch (err) {
     process.stderr.write(`caracal: failed to build TypeScript workspace packages: ${err?.message ?? err}\n`)
     process.exit(1)
@@ -87,7 +88,7 @@ try {
   process.exit(1)
 }
 
-import(join(root, 'apps/runtime/bin/caracal.mjs')).catch((err) => {
+import(pathToFileURL(join(root, 'apps/runtime/bin/caracal.mjs')).href).catch((err) => {
   process.stderr.write(`caracal: ${err?.message ?? err}\n`)
   process.exit(1)
 })


### PR DESCRIPTION
## Summary

Two portability bugs prevent `pnpm caracal up` and `pnpm caracal console` from running on Windows from a fresh clone. Both live in the workspace shims and have identical root causes in the runtime and Console binaries.

### F-001 — `spawnSync pnpm ENOENT`

`execFileSync('pnpm', ...)` cannot resolve the `pnpm.CMD` shim on Windows because Node does not consult `PATHEXT`. Replaced the call with `execSync('pnpm run build:typescript', ...)` — the string form goes through a shell which honors `PATHEXT`, and the single-string API does not trigger the Node 24 `DEP0190` warning that `shell: true` + args-array combination raises.

### F-002 — `Only URLs with a scheme in: file, data, and node are supported... Received protocol 'c:'`

Dynamic `import(join(root, 'apps/runtime/bin/caracal.mjs'))` fails on Windows because `path.join` returns `C:\...` and Node's ESM loader parses the leading `C:` as a URL scheme. Wrapped both call sites with `pathToFileURL(...).href` so the import receives a valid `file://` URL.

## Files

- `apps/runtime/bin/caracal-workspace.mjs`
- `apps/console/bin/caracal-console-workspace.mjs`

## Test plan

- [x] On Windows 11, fresh clone → `pnpm install` → `pnpm caracal up` proceeds past the TypeScript build and dev-SHA stamp without errors
- [x] No `DEP0190` deprecation warning in the output
- [ ] On Linux/macOS, `pnpm caracal up` behavior unchanged (please verify in CI)

## Rule alignment

The original code violated `.claude/rules/latest-stable-portability.instructions.md`:
- Line 13 (no shell-specific behavior or filesystem assumptions in feature code) — the shim assumed POSIX `execve` semantics and POSIX path-as-URL semantics.
- Line 14 (default to portable APIs) — fix uses `execSync` and `pathToFileURL`, both single portable calls with no `process.platform` branches.
