### PR TITLE
fix(sts): resolve key rotation validation bug using kid-based key lookup

### DIFF
--- a/services/sts/internal/exchange.go
+++ b/services/sts/internal/exchange.go
@@ -643,10 +643,14 @@ func (s *Server) authenticateApp(ctx context.Context, req TokenExchangeRequest) 
 // as issuer, the issuer audience, a matching zone_id, and use=session. Resource mandates
 // are deliberately rejected here (RFC 8693 §2.1 subject-confusion mitigation): a token
 // already narrowed to resources A,B must not bootstrap the minting of one for resource C.
+//
+// The keyfunc extracts the token's kid header and selects the matching verification key
+// from the zone's active + grace-period key set, ensuring tokens signed by a previous
+// key during key rotation are still accepted within the 24h grace window.
 func (s *Server) validateSubjectToken(ctx context.Context, tokenStr, zoneID string) (map[string]any, error) {
-	pub, _, err := s.keys.getPublicKeyAndKid(ctx, zoneID)
+	zoneKeys, err := s.keys.getPublicKeysByZone(ctx, zoneID)
 	if err != nil {
-		return nil, fmt.Errorf("get zone key: %w", err)
+		return nil, fmt.Errorf("get zone keys: %w", err)
 	}
 	mc := jwt.MapClaims{}
 	_, err = jwt.NewParser(
@@ -656,7 +660,15 @@ func (s *Server) validateSubjectToken(ctx context.Context, tokenStr, zoneID stri
 		jwt.WithExpirationRequired(),
 		jwt.WithIssuedAt(),
 		jwt.WithLeeway(60*time.Second),
-	).ParseWithClaims(tokenStr, mc, func(*jwt.Token) (any, error) {
+	).ParseWithClaims(tokenStr, mc, func(token *jwt.Token) (any, error) {
+		kid, ok := token.Header["kid"].(string)
+		if !ok || kid == "" {
+			return nil, errors.New("token missing kid header")
+		}
+		pub, found := zoneKeys[kid]
+		if !found {
+			return nil, fmt.Errorf("unknown signing key kid %q for zone %s", kid, zoneID)
+		}
 		return pub, nil
 	})
 	if err != nil {

--- a/services/sts/internal/exchange_test.go
+++ b/services/sts/internal/exchange_test.go
@@ -10,12 +10,17 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"net/http"
 	"testing"
 	"time"
 
+	sharedcrypto "github.com/garudex-labs/caracal/packages/core/go/crypto"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/open-policy-agent/opa/rego"
 )
 
@@ -213,6 +218,8 @@ type stubDB struct {
 	graphEpoch    int64
 	epochErr      error
 	sessErr       error
+	secrets       []SecretRow
+	secretsErr    error
 }
 
 func (s *stubDB) Ping(_ context.Context) error { return nil }
@@ -291,9 +298,21 @@ func (s *stubDB) EnsureZoneSigningKeySecret(_ context.Context, _ string, _, _ []
 	return nil, errors.New("stub")
 }
 func (s *stubDB) GetZoneSigningKeySecret(_ context.Context, _ string) (*SecretRow, error) {
+	if s.secretsErr != nil {
+		return nil, s.secretsErr
+	}
+	if len(s.secrets) > 0 {
+		return &s.secrets[0], nil
+	}
 	return nil, errors.New("stub")
 }
 func (s *stubDB) GetZoneSigningKeySecrets(_ context.Context, _ string) ([]SecretRow, error) {
+	if s.secretsErr != nil {
+		return nil, s.secretsErr
+	}
+	if len(s.secrets) > 0 {
+		return s.secrets, nil
+	}
 	return nil, errors.New("stub")
 }
 func (s *stubDB) GetActivePolicySetBinding(_ context.Context, _ string) (*PolicySetBinding, error) {
@@ -1339,4 +1358,134 @@ result := {"decision": "allow", "evaluation_status": "complete", "determining_po
 	if got := opaEngine.MetricsSnapshot().EvalTotal; got != 250 {
 		t.Fatalf("want 250 OPA evaluations, got %d", got)
 	}
+}
+
+func makeTestSecretRow(t *testing.T, zek []byte, priv *ecdsa.PrivateKey, kid string) SecretRow {
+	der, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+	ciphertext, nonce, err := sharedcrypto.Seal(zek, keyBytes)
+	if err != nil {
+		t.Fatalf("seal key: %v", err)
+	}
+	return SecretRow{
+		ID:         kid,
+		Ciphertext: ciphertext,
+		Nonce:      nonce,
+		DEKID:      "zoneKek",
+	}
+}
+
+func TestValidateSubjectTokenGracePeriodAndRotation(t *testing.T) {
+	// Setup keys and environment
+	zek := []byte("12345678901234567890123456789012")
+	keyCache := newKeyCache(nil, zek) // We will supply the db below
+
+	keyA, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key A: %v", err)
+	}
+	keyB, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key B: %v", err)
+	}
+
+	secretA := makeTestSecretRow(t, zek, keyA, "key-A")
+	secretB := makeTestSecretRow(t, zek, keyB, "key-B")
+
+	db := &stubDB{
+		secrets: []SecretRow{secretB, secretA}, // B is active/newest, A is grace-period/older
+	}
+	keyCache.db = db
+
+	srv := &Server{
+		cfg:  Config{IssuerURL: "https://sts.example.com"},
+		keys: keyCache,
+		db:   db,
+	}
+
+	// Helper to mint tokens
+	mintToken := func(priv *ecdsa.PrivateKey, kid string, useSession bool) string {
+		now := time.Now()
+		audience := []string{"https://sts.example.com"}
+		use := UseSession
+		if !useSession {
+			use = UseResource
+		}
+		claims := Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer:    "https://sts.example.com",
+				Subject:   "user-123",
+				Audience:  audience,
+				ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(now),
+				ID:        uuid.NewString(),
+			},
+			ZoneID: "zone-1",
+			Use:    use,
+		}
+		tok := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+		if kid != "" {
+			tok.Header["kid"] = kid
+		}
+		sig, err := tok.SignedString(priv)
+		if err != nil {
+			t.Fatalf("sign token: %v", err)
+		}
+		return sig
+	}
+
+	t.Run("AcceptsActiveKey", func(t *testing.T) {
+		tok := mintToken(keyB, "key-B", true)
+		claims, err := srv.validateSubjectToken(context.Background(), tok, "zone-1")
+		if err != nil {
+			t.Fatalf("expected active key to be accepted: %v", err)
+		}
+		if claims["sub"] != "user-123" {
+			t.Errorf("expected subject user-123, got %v", claims["sub"])
+		}
+	})
+
+	t.Run("AcceptsGracePeriodKey", func(t *testing.T) {
+		tok := mintToken(keyA, "key-A", true)
+		claims, err := srv.validateSubjectToken(context.Background(), tok, "zone-1")
+		if err != nil {
+			t.Fatalf("expected grace period key to be accepted: %v", err)
+		}
+		if claims["sub"] != "user-123" {
+			t.Errorf("expected subject user-123, got %v", claims["sub"])
+		}
+	})
+
+	t.Run("RejectsUnknownKid", func(t *testing.T) {
+		otherKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("generate unknown kid key: %v", err)
+		}
+		tok := mintToken(otherKey, "unknown-kid", true)
+		_, err = srv.validateSubjectToken(context.Background(), tok, "zone-1")
+		if err == nil {
+			t.Fatal("expected failure for unknown kid, got nil error")
+		}
+	})
+
+	t.Run("RejectsMissingKid", func(t *testing.T) {
+		tok := mintToken(keyB, "", true)
+		_, err := srv.validateSubjectToken(context.Background(), tok, "zone-1")
+		if err == nil {
+			t.Fatal("expected failure for missing kid, got nil error")
+		}
+	})
+
+	t.Run("RejectsResourceMandate", func(t *testing.T) {
+		tok := mintToken(keyB, "key-B", false)
+		_, err := srv.validateSubjectToken(context.Background(), tok, "zone-1")
+		if err == nil {
+			t.Fatal("expected resource mandate token to be rejected, got nil error")
+		} else if err.Error() != "subject_token must be a session mandate" {
+			t.Fatalf("expected rejection due to session mandate requirement, got: %v", err)
+		}
+	})
 }

--- a/services/sts/internal/jwt.go
+++ b/services/sts/internal/jwt.go
@@ -32,16 +32,27 @@ type zoneCacheEntry struct {
 	expiresAt time.Time
 }
 
+type publicKeysCacheEntry struct {
+	keys      map[string]*ecdsa.PublicKey
+	expiresAt time.Time
+}
+
 // KeyCache holds decrypted zone signing keys in memory with a 15-minute TTL.
 type KeyCache struct {
-	mu      sync.RWMutex
-	entries map[string]*zoneCacheEntry
-	db      DBQuerier
-	zek     []byte
+	mu           sync.RWMutex
+	entries      map[string]*zoneCacheEntry
+	pubKeysCache map[string]*publicKeysCacheEntry
+	db           DBQuerier
+	zek          []byte
 }
 
 func newKeyCache(db DBQuerier, zek []byte) *KeyCache {
-	return &KeyCache{entries: make(map[string]*zoneCacheEntry), db: db, zek: zek}
+	return &KeyCache{
+		entries:      make(map[string]*zoneCacheEntry),
+		pubKeysCache: make(map[string]*publicKeysCacheEntry),
+		db:           db,
+		zek:          zek,
+	}
 }
 
 func (k *KeyCache) getKeyAndKid(ctx context.Context, zoneID string) (*ecdsa.PrivateKey, string, error) {
@@ -106,9 +117,61 @@ func (k *KeyCache) getPublicKeyAndKid(ctx context.Context, zoneID string) (*ecds
 	return &priv.PublicKey, kid, nil
 }
 
+// getPublicKeysByZone returns all active and grace-period public keys for a zone,
+// keyed by kid. Used by validateSubjectToken to verify tokens signed by any key
+// in the current rotation window (active + previous key during 24h grace period).
+func (k *KeyCache) getPublicKeysByZone(ctx context.Context, zoneID string) (map[string]*ecdsa.PublicKey, error) {
+	k.mu.RLock()
+	e, ok := k.pubKeysCache[zoneID]
+	k.mu.RUnlock()
+	if ok && time.Now().Before(e.expiresAt) {
+		return e.keys, nil
+	}
+
+	secrets, err := k.db.GetZoneSigningKeySecrets(ctx, zoneID)
+	if err != nil {
+		return nil, fmt.Errorf("load zone signing keys for %s: %w", zoneID, err)
+	}
+	if len(secrets) == 0 {
+		return nil, fmt.Errorf("no signing keys for zone %s", zoneID)
+	}
+	keys := make(map[string]*ecdsa.PublicKey, len(secrets))
+	var decryptFailedKids []string
+	var parseFailedKids []string
+	for _, secret := range secrets {
+		keyBytes, err := sharedcrypto.Open(k.zek, secret.Nonce, secret.Ciphertext)
+		if err != nil {
+			decryptFailedKids = append(decryptFailedKids, secret.ID)
+			continue
+		}
+		priv, err := jwt.ParseECPrivateKeyFromPEM(keyBytes)
+		if err != nil {
+			parseFailedKids = append(parseFailedKids, secret.ID)
+			continue
+		}
+		keys[secret.ID] = &priv.PublicKey
+	}
+
+	if len(decryptFailedKids) > 0 || len(parseFailedKids) > 0 {
+		return nil, fmt.Errorf(
+			"load signing keys for zone %s: decryption failed for kids %v; PEM parsing failed for kids %v",
+			zoneID,
+			decryptFailedKids,
+			parseFailedKids,
+		)
+	}
+
+	k.mu.Lock()
+	k.pubKeysCache[zoneID] = &publicKeysCacheEntry{keys: keys, expiresAt: time.Now().Add(dekCacheTTL)}
+	k.mu.Unlock()
+
+	return keys, nil
+}
+
 func (k *KeyCache) Invalidate(zoneID string) {
 	k.mu.Lock()
 	delete(k.entries, zoneID)
+	delete(k.pubKeysCache, zoneID)
 	k.mu.Unlock()
 }
 


### PR DESCRIPTION
## PR Title

fix(sts): resolve key rotation validation bug using kid-based key lookup

## Summary

When a zone signing key was rotated, the token verification logic in `validateSubjectToken` unconditionally validated incoming tokens against the single, newly-promoted active key. This PR updates `KeyCache` to retrieve and decrypt all active and grace-period keys for a zone, and modifies `validateSubjectToken` to inspect the token's `kid` header and select the matching public key for signature verification. This ensures tokens signed by previous keys are accepted during the 24-hour key rotation grace window.

## Related Issue

<!-- One of: Fixes / Resolves / Closes -->
Fixes #188 


## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [x] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [ ] Local run
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes:
Added the `TestValidateSubjectTokenGracePeriodAndRotation` suite with subtests validating:
- Active key token verification
- Grace-period rotated key token verification
- Rejection of unknown kids and missing kids
- Rejection of resource-scoped tokens

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed


## Screenshots / Demos (if UI or UX)

<!-- Optional: add screenshot, GIF, or short note -->
N/A (backend crypto fix, no UI changes.)

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed
