### PR TITLE
fix: add .gitattributes to enforce LF line endings on Linux-runnable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+*.sh text eol=lf
+Dockerfile* text eol=lf
+*.dockerfile text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
## Summary

Without a checked-in `.gitattributes`, Git for Windows' default `core.autocrlf=true` converts every text file to CRLF on checkout — including shell scripts and Dockerfiles. Inside Linux-based containers this breaks two things:

- The kernel's shebang parser: `exec /bin/sh\r` fails with `No such file or directory` even though `/bin/sh` exists — the trailing `\r` makes it a different path
- The POSIX shell option parser: `set -eu\r` is read as `illegal option -`

On every Windows clone this currently breaks the redis container (entrypoint script can't exec) and the dbMigrate one-shot (migrate script can't parse `set`). The build succeeds, then containers exit immediately at startup, which makes diagnosis painful.

## Fix

Add a root `.gitattributes` that pins `*.sh`, `Dockerfile*`, `*.dockerfile`, `*.yml`, and `*.yaml` to LF, and sets `* text=auto eol=lf` so every other text file Git detects also stays LF. This overrides any contributor's local `core.autocrlf` setting.

No existing tracked files need renormalization — every `*.sh` / Dockerfile / yml in the index is already LF. The bug is purely that nothing was preventing Git from converting them on Windows checkout.

## Files

- `.gitattributes` (new)

## Test plan

- [x] On Windows with `core.autocrlf=true`, `git ls-files --eol` shows `w/lf` for `*.sh` and Dockerfile paths after this change (verified locally — see below)
- [ ] On Linux/macOS, behavior unchanged (LF was already the default)
- [ ] redis container starts successfully on Windows after re-clone

Local verification output:

```
i/lf    w/lf    attr/text eol=lf        infra/docker/Dockerfile.go-service
i/lf    w/lf    attr/text eol=lf        infra/postgres/scripts/migrate.sh
i/lf    w/lf    attr/text eol=lf        infra/redis/entrypoint.sh
```


## Note for existing Windows clones

Contributors who cloned the repo before this change have CRLF in their working tree. After pulling, they should run:

```sh
git rm --cached -r .
git reset --hard HEAD
```

to refresh the working tree from the LF-normalized index.