### PR TITLE
fix: use process.exitCode in status command

### DIFF
--- a/apps/runtime/src/commands/stack.ts
+++ b/apps/runtime/src/commands/stack.ts
@@ -118,7 +118,8 @@ export async function statusCommand(argv: string[] = []): Promise<void> {
   const results = await stackStatus({ probes })
   if (json) {
     printJSON({ mode: kind, services: results })
-    process.exit(results.every((r) => r.ok) ? 0 : 1)
+    process.exitCode = results.every((r) => r.ok) ? 0 : 1
+    return
   }
   printBanner(paths)
   const width = probes.reduce((m, s) => Math.max(m, s.name.length), 0)
@@ -134,7 +135,7 @@ export async function statusCommand(argv: string[] = []): Promise<void> {
       `${r.name.padEnd(width)}  ${String(r.port).padStart(5)}  ${kind.padEnd(6)}  ${mark} ${status}  ${style.label(r.detail)}\n`,
     )
   }
-  process.exit(allOk ? 0 : 1)
+  process.exitCode = allOk ? 0 : 1
 }
 
 function statusHelp(): never {

--- a/tests/typescript/unit/runtime/status.test.ts
+++ b/tests/typescript/unit/runtime/status.test.ts
@@ -6,6 +6,7 @@
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import process from 'node:process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { statusCommand } from '../../../../apps/runtime/src/commands/stack.js'
 
@@ -14,18 +15,18 @@ describe('statusCommand', () => {
 
   beforeEach(() => {
     stdout = ''
+    process.exitCode = undefined
     vi.stubEnv('CARACAL_MODE', 'stable')
     vi.stubEnv('CARACAL_HOME', mkdtempSync(join(tmpdir(), 'caracal-home-')))
     vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
       stdout += chunk.toString()
       return true
     })
-    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
-      throw new Error(`exit:${code}`)
-    })
+    vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
   })
 
   afterEach(() => {
+    process.exitCode = undefined
     vi.unstubAllEnvs()
     vi.restoreAllMocks()
   })
@@ -33,8 +34,10 @@ describe('statusCommand', () => {
   it('exits zero when all service probes are healthy', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }))
 
-    await expect(statusCommand()).rejects.toThrow('exit:0')
+    await statusCommand()
 
+    expect(process.exitCode).toBe(0)
+    expect(process.exit).not.toHaveBeenCalled()
     expect(stdout).toContain('api          ')
     expect(stdout).toContain(' 3000  ')
     expect(stdout).toContain('ok')
@@ -49,8 +52,10 @@ describe('statusCommand', () => {
       .mockResolvedValue({ ok: true, status: 200 })
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(statusCommand()).rejects.toThrow('exit:1')
+    await statusCommand()
 
+    expect(process.exitCode).toBe(1)
+    expect(process.exit).not.toHaveBeenCalled()
     expect(stdout).toContain('api          ')
     expect(stdout).toContain('sts          ')
     expect(stdout).toContain('down')
@@ -61,8 +66,10 @@ describe('statusCommand', () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(statusCommand(['--ready', '--json'])).rejects.toThrow('exit:0')
+    await statusCommand(['--ready', '--json'])
 
+    expect(process.exitCode).toBe(0)
+    expect(process.exit).not.toHaveBeenCalled()
     expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
       'http://localhost:3000/ready',
       'http://localhost:8080/ready',
@@ -85,8 +92,10 @@ describe('statusCommand', () => {
       .mockResolvedValue({ ok: true, status: 200 })
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(statusCommand(['--ready', '--json'])).rejects.toThrow('exit:1')
+    await statusCommand(['--ready', '--json'])
 
+    expect(process.exitCode).toBe(1)
+    expect(process.exit).not.toHaveBeenCalled()
     const body = JSON.parse(stdout)
     expect(body.services[1]).toMatchObject({
       name: 'sts',


### PR DESCRIPTION
## Summary

`pnpm caracal status --ready` prints its results table correctly, then on Windows emits:

Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94

## Root cause

`statusCommand` in `apps/runtime/src/commands/stack.ts` runs parallel `fetch()` calls to probe each service. Node's built-in `fetch` is implemented via undici, which maintains keep-alive sockets behind a global dispatcher. After the table prints, the command calls `process.exit(code)`. `process.exit` is the "stop everything now" call — it bypasses Node's natural cleanup and force-closes every libuv handle immediately, while undici's own close path is still running on those same handles.

On POSIX, libuv's `uv__async_close` silently no-ops a close call on a handle already in the closing state, so the assertion never fires. On Windows libuv asserts (`src\win\async.c:94`). The bug existed on every platform — it's just only visible on Windows.

## Fix

Replace both `process.exit(code)` calls in `statusCommand` with `process.exitCode = code` + `return`. This lets Node's normal event-loop drain close the undici handles in order, with each handle closed exactly once and no race.

## Files

- `apps/runtime/src/commands/stack.ts`

## Test plan

- [x] On Windows, `pnpm caracal status --ready` no longer emits the libuv assertion after the table prints
- [ ] On Linux/macOS, behavior unchanged (was already silent there)
- [x] Exit code matches the all-services-ok / any-service-down state (verified with `; Write-Host "exit code: $LASTEXITCODE"`)