### PR TITLE
fix: enable BuildKit and inherit Windows env for Compose builds

### DIFF
--- a/apps/runtime/src/commands/stack.ts
+++ b/apps/runtime/src/commands/stack.ts
@@ -74,6 +74,8 @@ export function composeEnv(paths: StackPaths): Record<string, string | undefined
   const env: Record<string, string | undefined> = {
     CARACAL_MODE: paths.mode,
     CARACAL_SECRETS_DIR: paths.secretsDir,
+    DOCKER_BUILDKIT: '1',
+    COMPOSE_DOCKER_CLI_BUILD: '1',
   }
   if (paths.mode !== 'dev') {
     env.CARACAL_VERSION = CARACAL_VERSION

--- a/packages/engine/src/run.ts
+++ b/packages/engine/src/run.ts
@@ -32,7 +32,6 @@ const BLOCKED_CREDENTIAL_ENV = new Set([
 
 const INHERITED_ENV_KEYS = new Set([
   'PATH',
-  'Path',
   'HOME',
   'USER',
   'LOGNAME',
@@ -52,7 +51,18 @@ const INHERITED_ENV_KEYS = new Set([
   'XDG_CONFIG_HOME',
   'XDG_CACHE_HOME',
   'XDG_DATA_HOME',
-])
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'PROGRAMDATA',
+  'PROGRAMFILES',
+  'PROGRAMFILES(X86)',
+  'SYSTEMROOT',
+  'WINDIR',
+  'COMSPEC',
+].map((key) => key.toUpperCase()))
 
 export type RunLineSink = (line: string, stream: 'stdout' | 'stderr') => void
 
@@ -181,7 +191,8 @@ function validateArgv(argv: string[]): void {
 }
 
 function shouldInheritEnv(key: string): boolean {
-  return INHERITED_ENV_KEYS.has(key) || key.startsWith('LC_')
+  const upper = key.toUpperCase()
+  return INHERITED_ENV_KEYS.has(upper) || upper.startsWith('LC_')
 }
 
 function validateChildEnvKey(key: string): void {

--- a/tests/typescript/unit/runtime/stack-command.test.ts
+++ b/tests/typescript/unit/runtime/stack-command.test.ts
@@ -121,4 +121,30 @@ describe('stack commands', () => {
     expect(stdout).not.toContain('runtime onboarding complete')
     expect(stdout).not.toContain('runtime config not found')
   })
+
+  it('forwards BuildKit env to compose when starting the stack', async () => {
+    await expect(upCommand(['api'])).rejects.toThrow('exit:0')
+
+    expect(engineMocks.stackUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          DOCKER_BUILDKIT: '1',
+          COMPOSE_DOCKER_CLI_BUILD: '1',
+        }),
+      }),
+    )
+  })
+
+  it('forwards BuildKit env to compose when stopping the stack', async () => {
+    await expect(downCommand([])).rejects.toThrow('exit:0')
+
+    expect(engineMocks.stackDown).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          DOCKER_BUILDKIT: '1',
+          COMPOSE_DOCKER_CLI_BUILD: '1',
+        }),
+      }),
+    )
+  })
 })


### PR DESCRIPTION
## Summary

On Windows, `pnpm caracal up` fails to build images. Compose prints "Docker Compose requires buildx plugin to be installed", falls back to the legacy builder, and then errors on BuildKit-only Dockerfile features (`COPY --chmod` in infra/postgres + infra/redis, `RUN --mount=type=cache` in the Go service Dockerfiles).

## Root cause

Two compounding issues in how the runtime spawns `docker compose`:

1. Caracal never tells Compose to use BuildKit. Its Dockerfiles require BuildKit, but `caracal up` spawned Compose without `DOCKER_BUILDKIT=1`, leaving the builder choice to Compose's default.

2. The engine strips the env vars Docker needs to find buildx. `runExec` forwards only a whitelist of environment variables to child processes. The whitelist covered POSIX vars (`HOME`, `XDG_*`, ...) but none of the Windows variables Docker uses to locate its `cli-plugins` directory (`ProgramFiles`, `ProgramData`, `UserProfile`). So even when told to use BuildKit, Compose could not find the buildx plugin and fell back to the legacy builder. The whitelist check was also case-sensitive, and Windows reports these names in mixed case (`ProgramFiles`, not `PROGRAMFILES`), so a naive uppercase entry would not match.

## Fix

apps/runtime/src/commands/stack.ts — force BuildKit on every Compose invocation:

    const env: Record<string, string | undefined> = {
      CARACAL_MODE: paths.mode,
      DOCKER_BUILDKIT: '1',
      COMPOSE_DOCKER_CLI_BUILD: '1',
    }

packages/engine/src/run.ts — forward the Windows env vars Docker needs and match names case-insensitively:

    const INHERITED_ENV_KEYS = new Set([
      'PATH', 'HOME', ...,
      'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'APPDATA', 'LOCALAPPDATA',
      'PROGRAMDATA', 'PROGRAMFILES', 'PROGRAMFILES(X86)', 'SYSTEMROOT',
      'WINDIR', 'COMSPEC',
    ].map((key) => key.toUpperCase()))

    function shouldInheritEnv(key: string): boolean {
      const upper = key.toUpperCase()
      return INHERITED_ENV_KEYS.has(upper) || upper.startsWith('LC_')
    }

Case-insensitive matching makes the redundant `Path` entry unnecessary (it folds into `PATH`), so it was removed.

## Why this approach

- Fixes all BuildKit-dependent Dockerfiles at once, not just the two using `COPY --chmod`. The Dockerfiles stay consistent — no need to special-case one BuildKit feature while leaving the others.
- No `process.platform` branch. Case-insensitive env matching is correct on Windows (where env var names are case-insensitive) and harmless on POSIX (the existing names still match). This satisfies the repo's portability rule, which forbids spreading platform checks through feature code.

## Files

- `apps/runtime/src/commands/stack.ts`
- `packages/engine/src/run.ts`

## Test plan

- [x] On Windows, `pnpm caracal up` builds all images via BuildKit and brings the stack up; `pnpm caracal status --ready` returns ok 200 for api/sts/gateway/audit/coordinator — with no host-side workarounds (no manual buildx copy, no shell env vars)
- [x] `pnpm -r typecheck` passes
- [x] Engine/runtime test suites: no new failures (the env-inheritance test in run.test.ts still passes; pre-existing Windows-only `0o600`/POSIX-path test failures are unrelated)
- [ ] On Linux/macOS, behavior unchanged: `DOCKER_BUILDKIT=1` is a no-op where BuildKit is already default; the added Windows vars do not exist in the POSIX environment; case-insensitive matching still matches the existing POSIX names