### PR TITLE
feat: fail fast when BuildKit is unavailable

### DIFF
--- a/apps/runtime/src/commands/stack.ts
+++ b/apps/runtime/src/commands/stack.ts
@@ -59,6 +59,15 @@ function requireDockerCompose(): void {
   process.exit(1)
 }
 
+function requireBuildKit(): void {
+  if (spawnSync('docker', ['buildx', 'version'], { stdio: 'ignore' }).status === 0) return
+  printError(
+    'BuildKit is required to build the Caracal stack but `docker buildx` is not available. ' +
+      'Install the buildx plugin: https://docs.docker.com/build/architecture/#install-buildx',
+  )
+  process.exit(1)
+}
+
 function printBanner(paths: StackPaths): void {
   const tag =
     paths.mode === 'dev'
@@ -90,6 +99,7 @@ export function composeEnv(paths: StackPaths): Record<string, string | undefined
 export async function upCommand(argv: string[]): Promise<void> {
   const paths = resolvePaths()
   requireDockerCompose()
+  if (paths.mode === 'dev') requireBuildKit()
   printBanner(paths)
   const handle = stackUp({ paths, args: argv, env: composeEnv(paths) })
   const code = await handle.exitCode

--- a/tests/typescript/unit/runtime/stack-command.test.ts
+++ b/tests/typescript/unit/runtime/stack-command.test.ts
@@ -103,6 +103,18 @@ describe('stack commands', () => {
     expect(engineMocks.stackUp).not.toHaveBeenCalled()
   })
 
+  it('fails up before spawning when BuildKit is unavailable in dev mode', async () => {
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'buildx') return { status: 127 }
+      return { status: 0 }
+    })
+
+    await expect(upCommand([])).rejects.toThrow('exit:1')
+
+    expect(stderr).toContain('BuildKit is required to build the Caracal stack')
+    expect(engineMocks.stackUp).not.toHaveBeenCalled()
+  })
+
   it('runs up when Docker Compose is available', async () => {
     await expect(upCommand(['api'])).rejects.toThrow('exit:0')
 


### PR DESCRIPTION
## Summary

Follow-up to #197 (the F-003 BuildKit fix). That PR makes `caracal up` force BuildKit (`DOCKER_BUILDKIT=1`) and forwards the Windows env vars Docker needs to find buildx. But it assumed BuildKit is actually present. On machines without it — old Docker, or Docker without the buildx plugin — the build still fails, just with cryptic errors (`the --chmod option requires BuildKit`, `--mount requires BuildKit`).

This PR makes that case fail fast with a clear, actionable message instead.

## Change

Add a `requireBuildKit()` preflight in `apps/runtime/src/commands/stack.ts`, sibling to the existing `requireDockerCompose()`. It runs `docker buildx version`; if buildx is missing, it errors with install guidance and exits before any build is attempted:

    function requireBuildKit(): void {
      if (spawnSync('docker', ['buildx', 'version'], { stdio: 'ignore' }).status === 0) return
      printError(
        'BuildKit is required to build the Caracal stack but `docker buildx` is not available. ' +
          'Install the buildx plugin: https://docs.docker.com/build/architecture/#install-buildx',
      )
      process.exit(1)
    }

Wired into `upCommand`, gated to dev mode (only dev builds images; rc/stable pull pre-built images and do not need BuildKit):

    if (paths.mode === 'dev') requireBuildKit()

`process.exit(1)` is used (not `process.exitCode`) because this is a synchronous preflight guard that must hard-stop before any async work — matching the existing `requireDockerCompose()` guard. No async handles are open at this point, so the Windows libuv-shutdown concern from the status command does not apply here.

## Files

- `apps/runtime/src/commands/stack.ts`
- `tests/typescript/unit/runtime/stack-command.test.ts`

## Test plan

- [x] Added: "fails up before spawning when BuildKit is unavailable in dev mode" — asserts the clear error and that `stackUp` is never called
- [x] Existing preflight tests still pass (compose-unavailable, daemon-unavailable, normal up/down)
- [x] `pnpm --filter @caracalai/runtime` typecheck passes
- [ ] On a machine without buildx, `caracal up` now prints the install message and exits 1 instead of failing mid-build

## Why

Without this, the F-003 fix silently degrades to confusing build errors on machines lacking BuildKit. This turns it into an upfront, fixable message — the "enforce BuildKit" option discussed in the F-003 review.

Closes #189 
