### PR TITLE
fix(sts): add net.cidr_merge to forbiddenBuiltins capability map

### DIFF
--- a/services/sts/internal/opa.go
+++ b/services/sts/internal/opa.go
@@ -33,6 +33,7 @@ var forbiddenBuiltins = map[string]struct{}{
 	"net.cidr_contains":   {},
 	"net.cidr_intersects": {},
 	"net.cidr_expand":     {},
+	"net.cidr_merge":      {},
 	"opa.runtime":         {},
 	"rand.intn":           {},
 	"time.now_ns":         {},

--- a/tests/go/unit/sts/internal/opa_test.go
+++ b/tests/go/unit/sts/internal/opa_test.go
@@ -232,3 +232,24 @@ func TestOPALoadZoneRejectsPartialBundle(t *testing.T) {
 		t.Fatal("want error when manifest version count mismatches DB result")
 	}
 }
+
+func TestOPAForbiddenBuiltins(t *testing.T) {
+	forbidden := []string{
+		`result := {"decision": "allow", "evaluation_status": "complete", "determining_policies": [], "diagnostics": [net.cidr_merge(["1.1.1.1/32"])]}`,
+		`result := {"decision": "allow", "evaluation_status": "complete", "determining_policies": [], "diagnostics": [http.send({"method": "get", "url": "http://localhost"})]}`,
+		`result := {"decision": "allow", "evaluation_status": "complete", "determining_policies": [], "diagnostics": [time.now_ns()]}`,
+	}
+
+	for i, f := range forbidden {
+		regoSource := "package caracal.authz\n" + f
+		_, err := rego.New(
+			rego.Module("forbidden.rego", regoSource),
+			rego.Query("result = data.caracal.authz.result"),
+			rego.Capabilities(safeCapabilities()),
+		).PrepareForEval(context.Background())
+		if err == nil {
+			t.Errorf("case %d: expected forbidden builtin to cause compilation failure, but it compiled successfully", i)
+		}
+	}
+}
+


### PR DESCRIPTION
## PR Title

fix(sts): add net.cidr_merge to forbiddenBuiltins capability map


## Summary

This PR adds `net.cidr_merge` to the Go STS service runtime's AST capability blocklist (`forbiddenBuiltins` map) to establish strict parity with the API Gateway's static validation restrictions. This ensures that even if gateway-level static policy checks are bypassed (e.g. via direct database injection), the OPA compilation engine will fail-closed and reject the usage of CIDR merge functions within the policy sandbox.


## Related Issue

Fixes #198


## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [x] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [ ] Local run
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes: Verified by adding `TestOPAForbiddenBuiltins` to `opa_test.go` to assert that compiling a policy with `net.cidr_merge` (or other forbidden builtins) fails capability checking. The entire `services/sts` test suite passed successfully.



## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed


## Screenshots / Demos (if UI or UX)

N/A (Backend runtime security hardening)


## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed
