### PR TITLE
feat(providerlab): improve Pulse Market Data provider realism

### DIFF
--- a/examples/lynxCapital/_mock/providerlab/catalog.py
+++ b/examples/lynxCapital/_mock/providerlab/catalog.py
@@ -253,9 +253,11 @@ CATALOG: tuple[Provider, ...] = (
     Provider(
         id="pulse-market", brand="Pulse Market Data", category="api_key",
         protocol="sse", port=9418, industry="Market data",
-        tagline="Real-time FX and reference market data",
-        resources=("instruments", "rates", "snapshots"),
-        operations=("list_instruments", "get_snapshot", "stream_rates"),
+        tagline="Real-time FX rates, OHLC candles, reference rates, and streaming ticks",
+        resources=("instruments", "rates", "snapshots", "ohlc", "reference_rates", "subscriptions"),
+        operations=("list_instruments", "get_snapshot", "stream_rates",
+                    "get_ohlc", "get_reference_rates",
+                    "list_subscriptions", "create_subscription", "delete_subscription"),
         apikey_location="header", apikey_field="X-Api-Key",
     ),
     Provider(

--- a/examples/lynxCapital/_mock/providerlab/data/generators.py
+++ b/examples/lynxCapital/_mock/providerlab/data/generators.py
@@ -350,17 +350,89 @@ def users(seed: str, count: int) -> list[dict]:
     return out
 
 
+_FX_INSTRUMENTS: tuple[tuple, ...] = (
+    # (symbol, base, quote, description, realistic_mid, pip_size, lot_size, min_trade, liquidity_tier)
+    ("USD/EUR", "USD", "EUR", "US Dollar / Euro",            0.9241, 0.0001, 100_000, 1_000, "tier1"),
+    ("USD/GBP", "USD", "GBP", "US Dollar / British Pound",   0.7892, 0.0001, 100_000, 1_000, "tier1"),
+    ("USD/JPY", "USD", "JPY", "US Dollar / Japanese Yen",  149.62,  0.01,   100_000, 1_000, "tier1"),
+    ("USD/BRL", "USD", "BRL", "US Dollar / Brazilian Real",   4.972, 0.0001, 100_000, 5_000, "tier2"),
+    ("USD/SGD", "USD", "SGD", "US Dollar / Singapore Dollar", 1.341, 0.0001, 100_000, 1_000, "tier2"),
+    ("EUR/GBP", "EUR", "GBP", "Euro / British Pound",         0.854, 0.0001, 100_000, 1_000, "tier1"),
+    ("EUR/JPY", "EUR", "JPY", "Euro / Japanese Yen",        161.53,  0.01,   100_000, 1_000, "tier1"),
+    ("GBP/JPY", "GBP", "JPY", "British Pound / Japanese Yen", 189.1, 0.01,  100_000, 1_000, "tier2"),
+    ("USD/CAD", "USD", "CAD", "US Dollar / Canadian Dollar",  1.362, 0.0001, 100_000, 1_000, "tier1"),
+    ("EUR/CHF", "EUR", "CHF", "Euro / Swiss Franc",           0.968, 0.0001, 100_000, 1_000, "tier2"),
+    ("AUD/USD", "AUD", "USD", "Australian Dollar / US Dollar", 0.646, 0.0001, 100_000, 1_000, "tier2"),
+    ("NZD/USD", "NZD", "USD", "New Zealand Dollar / US Dollar", 0.601, 0.0001, 100_000, 1_000, "tier3"),
+    ("USD/CHF", "USD", "CHF", "US Dollar / Swiss Franc",      0.895, 0.0001, 100_000, 1_000, "tier1"),
+    ("EUR/USD", "EUR", "USD", "Euro / US Dollar",             1.082, 0.0001, 100_000, 1_000, "tier1"),
+    ("GBP/USD", "GBP", "USD", "British Pound / US Dollar",   1.267, 0.0001, 100_000, 1_000, "tier1"),
+)
+
+_FX_VENUES: dict[str, str] = {
+    "LDN": "London",
+    "NYC": "New York",
+    "SGP": "Singapore",
+    "TKY": "Tokyo",
+    "FRA": "Frankfurt",
+    "SYD": "Sydney",
+}
+
+_TRADING_SESSIONS: dict[str, tuple[str, str]] = {
+    "LDN": ("08:00", "17:00"),
+    "NYC": ("13:00", "22:00"),
+    "SGP": ("00:00", "09:00"),
+    "TKY": ("00:00", "09:00"),
+    "FRA": ("07:00", "15:30"),
+    "SYD": ("22:00", "07:00"),
+}
+
+
 def instruments(seed: str) -> list[dict]:
-    pairs = ("USD/EUR", "USD/GBP", "USD/JPY", "USD/BRL", "USD/SGD", "EUR/GBP",
-             "EUR/JPY", "GBP/JPY", "USD/CAD", "EUR/CHF")
     out = []
-    for sym in pairs:
+    for sym, base, quote, description, nominal_mid, pip_size, lot_size, min_trade, liq_tier in _FX_INSTRUMENTS:
         rng = _rng(seed, "instrument", sym)
+        # Apply a small deterministic perturbation to the nominal mid so the
+        # seeded price reflects live-ish variation without changing on every run.
+        perturbation = rng.uniform(-0.012, 0.012)
+        mid = round(nominal_mid * (1.0 + perturbation), 4 if pip_size == 0.0001 else 2)
+        spread_bps = rng.randint(2, 18)
+        venue_code = rng.choice(("LDN", "NYC", "SGP", "TKY", "FRA", "SYD"))
+        # Derive a realistic day range centered on mid.
+        day_range_pct = rng.uniform(0.003, 0.012)
+        day_open = round(mid * (1.0 + rng.uniform(-day_range_pct / 2, day_range_pct / 2)),
+                         4 if pip_size == 0.0001 else 2)
+        day_low = round(min(mid, day_open) * (1.0 - rng.uniform(0.001, day_range_pct / 2)),
+                        4 if pip_size == 0.0001 else 2)
+        day_high = round(max(mid, day_open) * (1.0 + rng.uniform(0.001, day_range_pct / 2)),
+                         4 if pip_size == 0.0001 else 2)
+        prev_close = round(mid * (1.0 + rng.uniform(-day_range_pct, day_range_pct)),
+                           4 if pip_size == 0.0001 else 2)
+        session_open, session_close = _TRADING_SESSIONS[venue_code]
         out.append({
             "symbol": sym,
-            "mid": round(rng.uniform(0.6, 160.0), 4),
-            "spreadBps": rng.randint(2, 18),
-            "venue": rng.choice(("LDN", "NYC", "SGP", "TKY")),
+            "base": base,
+            "quote": quote,
+            "description": description,
+            "type": "fx",
+            "assetClass": "FX",
+            "exchange": "OTC",
+            "venue": venue_code,
+            "venueName": _FX_VENUES[venue_code],
+            "tradingHours": f"{session_open}-{session_close} UTC",
+            "tradingDays": "Mon-Fri",
+            "liquidityTier": liq_tier,
+            "pipSize": pip_size,
+            "lotSize": lot_size,
+            "minTradeSize": min_trade,
+            "mid": mid,
+            "spreadBps": spread_bps,
+            "dayOpen": day_open,
+            "dayHigh": day_high,
+            "dayLow": day_low,
+            "prevClose": prev_close,
+            "change": round(mid - prev_close, 4 if pip_size == 0.0001 else 2),
+            "changePct": round((mid - prev_close) / prev_close * 100, 4),
         })
     return out
 

--- a/examples/lynxCapital/_mock/providerlab/providers/pulse_market.py
+++ b/examples/lynxCapital/_mock/providerlab/providers/pulse_market.py
@@ -2,13 +2,12 @@
 Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
 Caracal, a product of Garudex Labs
 
-Pulse Market Data domain: real-time FX instruments, point-in-time snapshots, OHLC candles,
-ECB-style daily reference rates, and streamable rate ticks.  Authentication: API Key (header).
+Pulse Market Data provider mock for API-key FX instruments, snapshots, OHLC candles, reference rates, and streaming ticks.
 """
 from __future__ import annotations
 
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from _mock.providerlab.data import generators as gen
 from _mock.providerlab.providers import base
@@ -61,7 +60,6 @@ def _utc_iso(ts: float) -> str:
 def seed(state: base.State) -> None:
     state.tables["instruments"] = gen.index_by(gen.instruments(ID), key="symbol")
     state.tables["subscriptions"] = {}
-    state.tables["reference_date"] = {}
 
 
 def _tick(inst: dict, seq: int, base_ts: float | None = None) -> dict:
@@ -77,7 +75,8 @@ def _tick(inst: dict, seq: int, base_ts: float | None = None) -> dict:
     bid = round(mid - half_spread, decimals)
     ask = round(mid + half_spread, decimals)
     volume = rng.randint(500_000, 12_000_000)
-    ts = (base_ts or time.time()) - seq * rng.uniform(0.08, 0.4)
+    ts0 = base_ts if base_ts is not None else time.time()
+    ts = ts0 - seq * 0.2 - rng.uniform(0.0, 0.05)
 
     # Intra-day change relative to the seeded day open.
     open_price = inst["dayOpen"]
@@ -105,7 +104,7 @@ def _tick(inst: dict, seq: int, base_ts: float | None = None) -> dict:
     }
 
 
-def _ohlc_candle(symbol: str, mid_base: float, pip: int, interval_sec: int,
+def _ohlc_candle(symbol: str, mid_base: float, pip: float, interval_sec: int,
                  candle_idx: int) -> dict:
     """Return one OHLC candle for a symbol, deterministically derived from its index."""
     decimals = 4 if pip == 0.0001 else 2

--- a/examples/lynxCapital/_mock/providerlab/providers/pulse_market.py
+++ b/examples/lynxCapital/_mock/providerlab/providers/pulse_market.py
@@ -2,9 +2,13 @@
 Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
 Caracal, a product of Garudex Labs
 
-Pulse Market Data domain: real-time FX instruments, point-in-time snapshots, and streamable rate ticks.
+Pulse Market Data domain: real-time FX instruments, point-in-time snapshots, OHLC candles,
+ECB-style daily reference rates, and streamable rate ticks.  Authentication: API Key (header).
 """
 from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
 
 from _mock.providerlab.data import generators as gen
 from _mock.providerlab.providers import base
@@ -12,31 +16,143 @@ from _mock.providerlab.providers.base import Ctx, DomainError
 
 ID = "pulse-market"
 
+# Supported OHLC intervals and how many seconds each bar spans.
+_INTERVALS: dict[str, int] = {
+    "1m":  60,
+    "5m":  300,
+    "15m": 900,
+    "1h":  3_600,
+    "4h":  14_400,
+    "1d":  86_400,
+}
+
+# ECB publishes reference rates for the major pairs against EUR.
+_ECB_BASE = "EUR"
+_ECB_PAIRS = ("EUR/USD", "EUR/GBP", "EUR/JPY", "EUR/CHF", "EUR/CAD",
+              "EUR/SGD", "EUR/BRL", "EUR/AUD", "EUR/NZD")
+
+# Market sessions with their approximate UTC coverage so callers can
+# understand which session a tick belongs to.
+_SESSIONS: list[tuple[int, int, str]] = [
+    (22, 7,  "sydney"),
+    (0,  9,  "asia"),
+    (7,  16, "london"),
+    (13, 22, "new_york"),
+]
+
+
+def _current_session() -> str:
+    hour = datetime.now(timezone.utc).hour
+    for start, end, name in _SESSIONS:
+        if start <= end:
+            if start <= hour < end:
+                return name
+        else:
+            if hour >= start or hour < end:
+                return name
+    return "after_hours"
+
+
+def _utc_iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
 
 @base.seeder(ID)
 def seed(state: base.State) -> None:
     state.tables["instruments"] = gen.index_by(gen.instruments(ID), key="symbol")
+    state.tables["subscriptions"] = {}
+    state.tables["reference_date"] = {}
 
 
-def _tick(symbol: str, base_mid: float, n: int) -> dict:
-    rng = gen._rng(ID, "tick", symbol, n)
-    mid = round(base_mid * (1 + rng.uniform(-0.002, 0.002)), 4)
-    return {"symbol": symbol, "bid": round(mid * 0.9995, 4), "ask": round(mid * 1.0005, 4),
-            "mid": mid, "seq": n}
+def _tick(inst: dict, seq: int, base_ts: float | None = None) -> dict:
+    """Generate one deterministic price tick for an instrument."""
+    symbol = inst["symbol"]
+    mid_base = inst["mid"]
+    pip = inst["pipSize"]
+    decimals = 4 if pip == 0.0001 else 2
 
+    rng = gen._rng(ID, "tick", symbol, seq)
+    mid = round(mid_base * (1 + rng.uniform(-0.002, 0.002)), decimals)
+    half_spread = round(mid * inst["spreadBps"] / 20_000, decimals)
+    bid = round(mid - half_spread, decimals)
+    ask = round(mid + half_spread, decimals)
+    volume = rng.randint(500_000, 12_000_000)
+    ts = (base_ts or time.time()) - seq * rng.uniform(0.08, 0.4)
+
+    # Intra-day change relative to the seeded day open.
+    open_price = inst["dayOpen"]
+    change = round(mid - open_price, decimals)
+    change_pct = round(change / open_price * 100, 4)
+
+    # Running session high/low — widen slightly with each tick.
+    session_high = round(max(inst["dayHigh"], mid) * (1 + seq * 0.000005), decimals)
+    session_low  = round(min(inst["dayLow"],  mid) * (1 - seq * 0.000005), decimals)
+
+    return {
+        "symbol": symbol,
+        "bid": bid,
+        "ask": ask,
+        "mid": mid,
+        "seq": seq,
+        "timestamp": _utc_iso(ts),
+        "change": change,
+        "changePct": change_pct,
+        "volume": volume,
+        "session": _current_session(),
+        "open": open_price,
+        "high": session_high,
+        "low": session_low,
+    }
+
+
+def _ohlc_candle(symbol: str, mid_base: float, pip: int, interval_sec: int,
+                 candle_idx: int) -> dict:
+    """Return one OHLC candle for a symbol, deterministically derived from its index."""
+    decimals = 4 if pip == 0.0001 else 2
+    rng = gen._rng(ID, "ohlc", symbol, interval_sec, candle_idx)
+    drift = rng.uniform(-0.006, 0.006)
+    open_p = round(mid_base * (1 + drift), decimals)
+    bar_range = rng.uniform(0.001, 0.008) * mid_base
+    high_p = round(open_p + rng.uniform(0, bar_range), decimals)
+    low_p  = round(open_p - rng.uniform(0, bar_range), decimals)
+    close_p = round(rng.uniform(low_p, high_p), decimals)
+    volume = rng.randint(1_000_000, 50_000_000)
+    bar_ts = time.time() - candle_idx * interval_sec
+    return {
+        "t": _utc_iso(bar_ts),
+        "o": open_p,
+        "h": high_p,
+        "l": low_p,
+        "c": close_p,
+        "v": volume,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Operations
+# ---------------------------------------------------------------------------
 
 @base.op(ID, "list_instruments")
 def list_instruments(ctx: Ctx) -> dict:
-    return {"items": list(ctx.state.table("instruments").values())}
+    """List all tradeable FX instruments with full reference data."""
+    items = list(ctx.state.table("instruments").values())
+    asset_class = ctx.get("assetClass")
+    liq_tier = ctx.get("liquidityTier")
+    if asset_class:
+        items = [i for i in items if i.get("assetClass") == asset_class]
+    if liq_tier:
+        items = [i for i in items if i.get("liquidityTier") == liq_tier]
+    return {"items": items, "total": len(items)}
 
 
 @base.op(ID, "get_snapshot")
 def get_snapshot(ctx: Ctx) -> dict:
+    """Return a point-in-time rate snapshot for one instrument."""
     ctx.require("symbol")
     inst = ctx.state.table("instruments").get(ctx.payload["symbol"])
     if inst is None:
         raise DomainError(404, "instrument_not_found", ctx.payload["symbol"])
-    return _tick(inst["symbol"], inst["mid"], 0)
+    return _tick(inst, 0)
 
 
 @base.op(ID, "stream_rates")
@@ -47,5 +163,123 @@ def stream_rates(ctx: Ctx) -> dict:
     if inst is None:
         raise DomainError(404, "instrument_not_found", ctx.payload["symbol"])
     count = max(1, min(int(ctx.get("ticks", 10)), 50))
-    return {"symbol": inst["symbol"],
-            "ticks": [_tick(inst["symbol"], inst["mid"], n) for n in range(count)]}
+    base_ts = time.time()
+    return {
+        "symbol": inst["symbol"],
+        "interval": ctx.get("interval", "tick"),
+        "ticks": [_tick(inst, n, base_ts) for n in range(count)],
+    }
+
+
+@base.op(ID, "get_ohlc")
+def get_ohlc(ctx: Ctx) -> dict:
+    """Return OHLC candles for one instrument.
+
+    Supported intervals: 1m, 5m, 15m, 1h, 4h, 1d (default 1d).
+    """
+    ctx.require("symbol")
+    inst = ctx.state.table("instruments").get(ctx.payload["symbol"])
+    if inst is None:
+        raise DomainError(404, "instrument_not_found", ctx.payload["symbol"])
+    interval = ctx.get("interval", "1d")
+    if interval not in _INTERVALS:
+        raise DomainError(422, "invalid_interval",
+                          f"interval must be one of: {', '.join(_INTERVALS)}")
+    limit = max(1, min(int(ctx.get("limit", 20)), 100))
+    interval_sec = _INTERVALS[interval]
+    candles = [
+        _ohlc_candle(inst["symbol"], inst["mid"], inst["pipSize"], interval_sec, i)
+        for i in range(limit - 1, -1, -1)
+    ]
+    now_iso = _utc_iso(time.time())
+    from_iso = _utc_iso(time.time() - limit * interval_sec)
+    return {
+        "symbol": inst["symbol"],
+        "interval": interval,
+        "from": from_iso,
+        "to": now_iso,
+        "candles": candles,
+    }
+
+
+@base.op(ID, "get_reference_rates")
+def get_reference_rates(ctx: Ctx) -> dict:
+    """Return ECB-style daily reference rates for all major pairs.
+
+    The optional ``date`` field accepts an ISO date string (YYYY-MM-DD).
+    When omitted the latest available fixing is returned.
+    """
+    date_str = ctx.get("date") or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    rng = gen._rng(ID, "refrate", date_str)
+    instruments = ctx.state.table("instruments")
+    rates = []
+    for sym in _ECB_PAIRS:
+        inst = instruments.get(sym)
+        if inst is None:
+            continue
+        # ECB rate is a deterministic perturbation of the seeded mid price.
+        perturb = rng.uniform(-0.0008, 0.0008)
+        pip = inst["pipSize"]
+        decimals = 4 if pip == 0.0001 else 2
+        rate = round(inst["mid"] * (1 + perturb), decimals)
+        rates.append({
+            "symbol": sym,
+            "rate": rate,
+            "base": inst["base"],
+            "quote": inst["quote"],
+            "source": "ECB",
+        })
+    return {
+        "date": date_str,
+        "publishedAt": f"{date_str}T14:15:00Z",
+        "baseCurrency": _ECB_BASE,
+        "source": "ECB",
+        "rates": rates,
+    }
+
+
+@base.op(ID, "list_subscriptions")
+def list_subscriptions(ctx: Ctx) -> dict:
+    """List active rate-stream subscriptions for the caller."""
+    items = [s for s in ctx.state.table("subscriptions").values()
+             if s["status"] == "active"]
+    return ctx.paginate(items)
+
+
+@base.op(ID, "create_subscription")
+def create_subscription(ctx: Ctx) -> dict:
+    """Subscribe to real-time rate events for an instrument."""
+    ctx.require("symbol")
+    inst = ctx.state.table("subscriptions")
+    instruments = ctx.state.table("instruments")
+    if ctx.payload["symbol"] not in instruments:
+        raise DomainError(404, "instrument_not_found", ctx.payload["symbol"])
+    sub_id = base.new_id("sub")
+    sub = {
+        "subscriptionId": sub_id,
+        "symbol": ctx.payload["symbol"],
+        "status": "active",
+        "callbackUrl": ctx.get("callbackUrl"),
+        "maxTicks": max(1, min(int(ctx.get("maxTicks", 50)), 50)),
+        "createdAt": base.now(),
+    }
+    inst[sub_id] = sub
+    return sub
+
+
+@base.op(ID, "delete_subscription")
+def delete_subscription(ctx: Ctx) -> dict:
+    """Cancel an active subscription by ID."""
+    ctx.require("subscriptionId")
+    subs = ctx.state.table("subscriptions")
+    sub = subs.get(ctx.payload["subscriptionId"])
+    if sub is None:
+        raise DomainError(404, "subscription_not_found", ctx.payload["subscriptionId"])
+    if sub["status"] != "active":
+        raise DomainError(409, "subscription_already_cancelled",
+                          f"subscription {ctx.payload['subscriptionId']} is already {sub['status']}")
+    sub = dict(sub)
+    sub["status"] = "cancelled"
+    sub["cancelledAt"] = base.now()
+    subs[ctx.payload["subscriptionId"]] = sub
+    return sub

--- a/examples/lynxCapital/tests/test_providerlab.py
+++ b/examples/lynxCapital/tests/test_providerlab.py
@@ -872,6 +872,283 @@ def test_ui_pages_render(path):
 
 
 # --------------------------------------------------------------------------- #
+# Pulse Market Data — api_key / sse provider with FX rates, OHLC, and subscriptions
+# --------------------------------------------------------------------------- #
+def _pulse_key() -> str:
+    return seed("pulse-market")["apiKey"]
+
+
+def _pulse_hdr() -> dict:
+    return {"X-Api-Key": _pulse_key()}
+
+
+def _pulse() -> TestClient:
+    return client("pulse-market")
+
+
+def test_pulse_market_api_key_accept_and_reject():
+    c = _pulse()
+    h = _pulse_hdr()
+    assert c.post("/api/list_instruments", headers=h).status_code == 200
+    assert c.post("/api/list_instruments", headers={"X-Api-Key": "bad-key"}).status_code == 401
+    assert c.post("/api/list_instruments").status_code == 401
+
+
+def test_pulse_market_list_instruments_realistic_schema():
+    items = _pulse().post("/api/list_instruments", json={}, headers=_pulse_hdr()).json()["data"]["items"]
+    assert len(items) >= 10
+    first = items[0]
+    assert {"symbol", "base", "quote", "description", "type", "assetClass",
+            "exchange", "venue", "pipSize", "lotSize", "minTradeSize",
+            "liquidityTier", "tradingHours", "tradingDays",
+            "mid", "spreadBps", "dayOpen", "dayHigh", "dayLow",
+            "prevClose", "change", "changePct"} <= first.keys()
+    assert first["type"] == "fx"
+    assert first["assetClass"] == "FX"
+    assert first["exchange"] == "OTC"
+    assert first["liquidityTier"] in ("tier1", "tier2", "tier3")
+    assert 0 < first["pipSize"] <= 0.01
+    assert first["lotSize"] >= 1_000
+    assert first["dayLow"] <= first["mid"] <= first["dayHigh"]
+
+
+def test_pulse_market_list_instruments_filter_by_liquidity_tier():
+    c = _pulse()
+    h = _pulse_hdr()
+    t1 = c.post("/api/list_instruments", json={"liquidityTier": "tier1"}, headers=h).json()["data"]
+    t3 = c.post("/api/list_instruments", json={"liquidityTier": "tier3"}, headers=h).json()["data"]
+    assert all(i["liquidityTier"] == "tier1" for i in t1["items"])
+    assert all(i["liquidityTier"] == "tier3" for i in t3["items"])
+    assert t1["total"] + t3["total"] < t1["total"] + t3["total"] + 1  # sanity: no overlap issue
+
+
+def test_pulse_market_snapshot_realistic_fields():
+    c = _pulse()
+    snap = c.post("/api/get_snapshot", json={"symbol": "USD/EUR"}, headers=_pulse_hdr()).json()["data"]
+    assert snap["symbol"] == "USD/EUR"
+    assert {"bid", "ask", "mid", "seq",
+            "timestamp", "change", "changePct",
+            "volume", "session", "open", "high", "low"} <= snap.keys()
+    # Spread must be positive and finite.
+    assert snap["bid"] < snap["ask"]
+    assert snap["bid"] > 0 and snap["ask"] > 0
+    # Timestamp must be an ISO UTC string.
+    assert snap["timestamp"].endswith("Z")
+    # Session is one of the known trading windows.
+    assert snap["session"] in ("sydney", "asia", "london", "new_york", "after_hours")
+    # Intra-day range constraint.
+    assert snap["low"] <= snap["mid"] <= snap["high"]
+
+
+def test_pulse_market_snapshot_jpy_pair_precision():
+    snap = _pulse().post("/api/get_snapshot", json={"symbol": "USD/JPY"},
+                         headers=_pulse_hdr()).json()["data"]
+    # JPY pairs are quoted to 2 decimal places, not 4.
+    assert snap["mid"] > 100, "USD/JPY mid should be above 100"
+    # Verify the pip size is 0.01 by checking the spread width.
+    spread = round(snap["ask"] - snap["bid"], 4)
+    assert spread < 2.0, "JPY spread in price terms should be small"
+
+
+def test_pulse_market_snapshot_unknown_symbol():
+    r = _pulse().post("/api/get_snapshot", json={"symbol": "XYZ/FAKE"}, headers=_pulse_hdr())
+    assert r.status_code == 404
+    assert r.json()["error"] == "instrument_not_found"
+
+
+def test_pulse_market_snapshot_missing_symbol_field():
+    r = _pulse().post("/api/get_snapshot", json={}, headers=_pulse_hdr())
+    assert r.status_code == 422
+    assert r.json()["error"] == "invalid_request"
+
+
+def test_pulse_market_stream_rates_tick_schema():
+    c = _pulse()
+    resp = c.post("/api/stream_rates", json={"symbol": "EUR/GBP", "ticks": 5},
+                  headers=_pulse_hdr()).json()["data"]
+    assert resp["symbol"] == "EUR/GBP"
+    assert len(resp["ticks"]) == 5
+    tick = resp["ticks"][0]
+    assert {"bid", "ask", "mid", "seq", "timestamp",
+            "change", "changePct", "volume", "session",
+            "open", "high", "low"} <= tick.keys()
+    assert tick["bid"] < tick["ask"]
+    assert tick["timestamp"].endswith("Z")
+    assert tick["volume"] > 0
+
+
+def test_pulse_market_stream_rates_count_clamped():
+    c = _pulse()
+    h = _pulse_hdr()
+    assert len(c.post("/api/stream_rates", json={"symbol": "USD/EUR", "ticks": 200},
+                      headers=h).json()["data"]["ticks"]) == 50
+    assert len(c.post("/api/stream_rates", json={"symbol": "USD/EUR", "ticks": 1},
+                      headers=h).json()["data"]["ticks"]) == 1
+
+
+def test_pulse_market_stream_rates_unknown_symbol():
+    r = _pulse().post("/api/stream_rates", json={"symbol": "AAA/BBB"}, headers=_pulse_hdr())
+    assert r.status_code == 404
+
+
+def test_pulse_market_ohlc_daily_candles():
+    c = _pulse()
+    resp = c.post("/api/get_ohlc", json={"symbol": "USD/EUR", "interval": "1d", "limit": 10},
+                  headers=_pulse_hdr()).json()["data"]
+    assert resp["symbol"] == "USD/EUR"
+    assert resp["interval"] == "1d"
+    assert len(resp["candles"]) == 10
+    assert "from" in resp and "to" in resp
+    candle = resp["candles"][0]
+    assert {"t", "o", "h", "l", "c", "v"} <= candle.keys()
+    assert candle["l"] <= candle["o"]
+    assert candle["l"] <= candle["c"]
+    assert candle["h"] >= candle["o"]
+    assert candle["h"] >= candle["c"]
+    assert candle["v"] > 0
+    assert candle["t"].endswith("Z")
+
+
+def test_pulse_market_ohlc_intraday_intervals():
+    c = _pulse()
+    h = _pulse_hdr()
+    for interval in ("1m", "5m", "15m", "1h", "4h"):
+        resp = c.post("/api/get_ohlc", json={"symbol": "EUR/USD", "interval": interval, "limit": 3},
+                      headers=h).json()["data"]
+        assert resp["interval"] == interval
+        assert len(resp["candles"]) == 3
+
+
+def test_pulse_market_ohlc_invalid_interval():
+    r = _pulse().post("/api/get_ohlc", json={"symbol": "USD/EUR", "interval": "2w"},
+                      headers=_pulse_hdr())
+    assert r.status_code == 422
+    assert r.json()["error"] == "invalid_interval"
+
+
+def test_pulse_market_ohlc_limit_clamped():
+    c = _pulse()
+    h = _pulse_hdr()
+    assert len(c.post("/api/get_ohlc", json={"symbol": "USD/EUR", "interval": "1d", "limit": 500},
+                      headers=h).json()["data"]["candles"]) == 100
+
+
+def test_pulse_market_ohlc_unknown_symbol():
+    r = _pulse().post("/api/get_ohlc", json={"symbol": "ZZZ/XXX", "interval": "1d"},
+                      headers=_pulse_hdr())
+    assert r.status_code == 404
+
+
+def test_pulse_market_reference_rates_schema():
+    c = _pulse()
+    resp = c.post("/api/get_reference_rates", json={}, headers=_pulse_hdr()).json()["data"]
+    assert "date" in resp and "rates" in resp and "source" in resp
+    assert resp["source"] == "ECB"
+    assert resp["baseCurrency"] == "EUR"
+    assert resp["publishedAt"].endswith("Z")
+    assert len(resp["rates"]) > 0
+    r = resp["rates"][0]
+    assert {"symbol", "rate", "base", "quote", "source"} <= r.keys()
+    assert r["source"] == "ECB"
+    assert r["rate"] > 0
+
+
+def test_pulse_market_reference_rates_with_date():
+    c = _pulse()
+    resp = c.post("/api/get_reference_rates", json={"date": "2026-01-15"},
+                  headers=_pulse_hdr()).json()["data"]
+    assert resp["date"] == "2026-01-15"
+    assert len(resp["rates"]) > 0
+
+
+def test_pulse_market_reference_rates_deterministic():
+    c = _pulse()
+    h = _pulse_hdr()
+    r1 = c.post("/api/get_reference_rates", json={"date": "2026-03-01"}, headers=h).json()["data"]
+    r2 = c.post("/api/get_reference_rates", json={"date": "2026-03-01"}, headers=h).json()["data"]
+    assert r1["rates"] == r2["rates"]
+    r3 = c.post("/api/get_reference_rates", json={"date": "2026-04-01"}, headers=h).json()["data"]
+    # Different date → different rates.
+    assert r1["rates"] != r3["rates"]
+
+
+def test_pulse_market_subscription_full_lifecycle():
+    c = _pulse()
+    h = _pulse_hdr()
+    # Create subscription.
+    created = c.post("/api/create_subscription", json={"symbol": "GBP/USD", "maxTicks": 20},
+                     headers=h).json()["data"]
+    assert created["symbol"] == "GBP/USD"
+    assert created["status"] == "active"
+    assert "subscriptionId" in created
+    assert "createdAt" in created
+    sub_id = created["subscriptionId"]
+
+    # Subscription appears in the list.
+    listing = c.post("/api/list_subscriptions", json={}, headers=h).json()["data"]
+    ids = [s["subscriptionId"] for s in listing["items"]]
+    assert sub_id in ids
+
+    # Delete the subscription.
+    deleted = c.post("/api/delete_subscription", json={"subscriptionId": sub_id},
+                     headers=h).json()["data"]
+    assert deleted["subscriptionId"] == sub_id
+    assert deleted["status"] == "cancelled"
+    assert "cancelledAt" in deleted
+
+    # Cancelled subscription no longer appears in the active list.
+    after = c.post("/api/list_subscriptions", json={}, headers=h).json()["data"]
+    assert sub_id not in [s["subscriptionId"] for s in after["items"]]
+
+
+def test_pulse_market_subscription_unknown_symbol():
+    r = _pulse().post("/api/create_subscription", json={"symbol": "FAKE/SYM"},
+                      headers=_pulse_hdr())
+    assert r.status_code == 404
+    assert r.json()["error"] == "instrument_not_found"
+
+
+def test_pulse_market_subscription_double_cancel():
+    c = _pulse()
+    h = _pulse_hdr()
+    sub = c.post("/api/create_subscription", json={"symbol": "USD/CAD"}, headers=h).json()["data"]
+    sub_id = sub["subscriptionId"]
+    c.post("/api/delete_subscription", json={"subscriptionId": sub_id}, headers=h)
+    replay = c.post("/api/delete_subscription", json={"subscriptionId": sub_id}, headers=h)
+    assert replay.status_code == 409
+    assert replay.json()["error"] == "subscription_already_cancelled"
+
+
+def test_pulse_market_subscription_not_found():
+    r = _pulse().post("/api/delete_subscription", json={"subscriptionId": "sub_does_not_exist"},
+                      headers=_pulse_hdr())
+    assert r.status_code == 404
+
+
+def test_pulse_market_sse_stream_delivers_ticks():
+    c = _pulse()
+    h = _pulse_hdr()
+    with c.stream("GET", "/stream", headers=h, params={"symbol": "USD/EUR", "ticks": 3}) as resp:
+        assert resp.status_code == 200
+        events = []
+        for line in resp.iter_lines():
+            if line.startswith("data:"):
+                import json as _json
+                events.append(_json.loads(line[5:].strip()))
+            if len(events) >= 3:
+                break
+    assert len(events) >= 1
+    tick = events[0]
+    assert {"bid", "ask", "mid", "seq", "timestamp"} <= tick.keys()
+
+
+def test_pulse_market_sse_stream_rejects_bad_key():
+    with _pulse().stream("GET", "/stream", headers={"X-Api-Key": "invalid"},
+                         params={"symbol": "USD/EUR", "ticks": 1}) as resp:
+        assert resp.status_code == 401
+
+
+# --------------------------------------------------------------------------- #
 # External-feel network behavior
 # --------------------------------------------------------------------------- #
 def test_responses_carry_request_id_header():

--- a/examples/lynxCapital/tests/test_providerlab.py
+++ b/examples/lynxCapital/tests/test_providerlab.py
@@ -919,7 +919,9 @@ def test_pulse_market_list_instruments_filter_by_liquidity_tier():
     t3 = c.post("/api/list_instruments", json={"liquidityTier": "tier3"}, headers=h).json()["data"]
     assert all(i["liquidityTier"] == "tier1" for i in t1["items"])
     assert all(i["liquidityTier"] == "tier3" for i in t3["items"])
-    assert t1["total"] + t3["total"] < t1["total"] + t3["total"] + 1  # sanity: no overlap issue
+    s1 = {i["symbol"] for i in t1["items"]}
+    s3 = {i["symbol"] for i in t3["items"]}
+    assert s1.isdisjoint(s3)
 
 
 def test_pulse_market_snapshot_realistic_fields():

--- a/examples/lynxCapital/uv.lock
+++ b/examples/lynxCapital/uv.lock
@@ -71,6 +71,105 @@ wheels = [
 ]
 
 [[package]]
+name = "caracalai-core"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/7d/4c43aa7a79acf90932c4abc54c8f716a140e9a221f8ae8c424d450c8248b/caracalai_core-0.1.4rc1.tar.gz", hash = "sha256:e03d2e0ba135c432228d5cc24cd92b28001f65f58e09f73ff684d728522e3820", size = 13786, upload-time = "2026-06-04T16:46:04.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0c/24c35b84a46f21fc86cb42428bddfc8d1bbaff2cd48536e103034be134f8/caracalai_core-0.1.4rc1-py3-none-any.whl", hash = "sha256:0c2e57cda06854efb5abc39051a71304b8fa65b0515746751e17390ffeafabce", size = 15432, upload-time = "2026-06-04T16:46:03.624Z" },
+]
+
+[[package]]
+name = "caracalai-identity"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caracalai-core" },
+    { name = "httpx" },
+    { name = "idna" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/a5/4279f6678201c6990ac31151229600225851657d22d5ada3c2607f9e8064/caracalai_identity-0.1.4rc1.tar.gz", hash = "sha256:c01bfd94512966c6a2a3fa795b20161fd0ca781fbfdec55239b08bd1fa3277f7", size = 9956, upload-time = "2026-06-04T16:46:02.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/eb/f5298d945e129c18c75c68b4747d83ab24c04ee4d9700e89381110eef99f/caracalai_identity-0.1.4rc1-py3-none-any.whl", hash = "sha256:ca0634544958b9f2a3bc31a7a5d58caeb80f5a98a6c2108f6b784e129d6b5c02", size = 11258, upload-time = "2026-06-04T16:46:01.913Z" },
+]
+
+[[package]]
+name = "caracalai-mcp-fastmcp"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caracalai-revocation" },
+    { name = "caracalai-transport-mcp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b2/c315a9646f0d16e5a84e108a2bb4636a548d211fac6ba4b59e342c5c432a/caracalai_mcp_fastmcp-0.1.4rc1.tar.gz", hash = "sha256:4486ffa5c02bd77be737d8a8d1c3d9e67140b9a125e1267317a1d3a11790c51c", size = 6493, upload-time = "2026-06-04T16:46:02.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/de/1d14fb503dba76f9489d1132574aad5da188d89b2f123166634b2be94326/caracalai_mcp_fastmcp-0.1.4rc1-py3-none-any.whl", hash = "sha256:f831190deaed4380366bd09b0cb1ff4b1a46283d1a14c1c2e3ecfc3e94a27a0e", size = 6674, upload-time = "2026-06-04T16:46:01.089Z" },
+]
+
+[[package]]
+name = "caracalai-oauth"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/88/154a5f11f0923e5c493f2b6f81bd0ad88d77e98e690b817b0941e74b3b00/caracalai_oauth-0.1.4rc1.tar.gz", hash = "sha256:0aa64cddb78140f5d8a93d16900d183a882d8ae4cb4a9a2893e879f276f2b123", size = 9206, upload-time = "2026-06-04T16:46:03.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/f4/0f4b9803d6b17525316a533bc0380f30e607ddc529940663ec7dca7e0213/caracalai_oauth-0.1.4rc1-py3-none-any.whl", hash = "sha256:29a2c54445a77dd9ae1488aea3ae17780abc27bcc09389d81020bb6d65daa90f", size = 10300, upload-time = "2026-06-04T16:46:01.994Z" },
+]
+
+[[package]]
+name = "caracalai-revocation"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/09/6b90c6e79f99203d5044777822aa83c4ca035166e7391f0cb936decdece8/caracalai_revocation-0.1.4rc1.tar.gz", hash = "sha256:e7ab99953618d4fc3e5477e04e23f443344cfc6d068703d8f42b39354f482233", size = 6315, upload-time = "2026-06-04T16:46:08.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/1a/776693e291f068256197d704ea1e6c21a001afa338a7e3c0261962f4d904/caracalai_revocation-0.1.4rc1-py3-none-any.whl", hash = "sha256:64137323c594641cfd4d95f895abf5de2f946776d616819cdc7fa605a84d75a6", size = 6921, upload-time = "2026-06-04T16:46:06.97Z" },
+]
+
+[[package]]
+name = "caracalai-revocation-redis"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caracalai-revocation" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/d1/496d4256a67e46bab82a259ad71f700a5a249ab61b9fdabcbd0e1475e890/caracalai_revocation_redis-0.1.4rc1.tar.gz", hash = "sha256:72ac7692972eda65ec139a3a0d79a79014ff916fba8a01785b81aad35a731e0b", size = 7812, upload-time = "2026-06-04T16:46:06.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/02/b3fcd7822d1ab581f64dd9e8ac29186077c2b7dde1b59eca6df828a9a56b/caracalai_revocation_redis-0.1.4rc1-py3-none-any.whl", hash = "sha256:ea9bb8007020a1e7a97dc4821d84319bbdaf22135b77bed7494b368deb80ad2e", size = 8099, upload-time = "2026-06-04T16:46:04.93Z" },
+]
+
+[[package]]
+name = "caracalai-sdk"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caracalai-identity" },
+    { name = "httpx" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/ed/25854337ea9287ab703a5cf2135d28f90f4aa919ee4e63f26b8090128f5f/caracalai_sdk-0.1.4rc1.tar.gz", hash = "sha256:b405a9dd62a83292ca5e435ae3b8a9e758ba87a3cd6505a713232616d5c31008", size = 23135, upload-time = "2026-06-04T16:46:06.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/85/d2fc845f0a64c7259aeb2e6fda412dd84218eaf25de1576f7a631f99c065/caracalai_sdk-0.1.4rc1-py3-none-any.whl", hash = "sha256:8d9ab5ac0a0d80b060fd5d9989c87f15dac726e01f2d524be39192b58413ac94", size = 27166, upload-time = "2026-06-04T16:46:05.16Z" },
+]
+
+[[package]]
+name = "caracalai-transport-mcp"
+version = "0.1.4rc1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caracalai-identity" },
+    { name = "caracalai-revocation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/81/aaa6da3ce79b2a8e24bbcbce5825df2abf49dc3b99abc8ac914462fcd117/caracalai_transport_mcp-0.1.4rc1.tar.gz", hash = "sha256:d9969594485c2b6ee0b579dec6019405e6c18a4110e765e4d97444f234a4409c", size = 8374, upload-time = "2026-06-04T16:46:04.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/56/14a3cc32dc08ca58e7c0449e5bd529b2a7e0c42066fdf3f76ddb2eed92f3/caracalai_transport_mcp-0.1.4rc1-py3-none-any.whl", hash = "sha256:fbd640c5be111160bf60064b4616f2d60c27bdcb3c11a2d8d73281bb8fdf8695", size = 9222, upload-time = "2026-06-04T16:46:03.53Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -825,6 +924,14 @@ name = "lynx-capital"
 version = "0.1.4rc1"
 source = { editable = "." }
 dependencies = [
+    { name = "caracalai-core" },
+    { name = "caracalai-identity" },
+    { name = "caracalai-mcp-fastmcp" },
+    { name = "caracalai-oauth" },
+    { name = "caracalai-revocation" },
+    { name = "caracalai-revocation-redis" },
+    { name = "caracalai-sdk" },
+    { name = "caracalai-transport-mcp" },
     { name = "deepagents" },
     { name = "fastapi" },
     { name = "grpcio" },
@@ -854,6 +961,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "caracalai-core", specifier = "==0.1.4rc1" },
+    { name = "caracalai-identity", specifier = "==0.1.4rc1" },
+    { name = "caracalai-mcp-fastmcp", specifier = "==0.1.4rc1" },
+    { name = "caracalai-oauth", specifier = "==0.1.4rc1" },
+    { name = "caracalai-revocation", specifier = "==0.1.4rc1" },
+    { name = "caracalai-revocation-redis", specifier = "==0.1.4rc1" },
+    { name = "caracalai-sdk", specifier = "==0.1.4rc1" },
+    { name = "caracalai-transport-mcp", specifier = "==0.1.4rc1" },
     { name = "deepagents", specifier = ">=0.6" },
     { name = "fastapi", specifier = ">=0.136" },
     { name = "grpcio", specifier = ">=1.80" },
@@ -1224,6 +1339,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Expands the Pulse Market Data mock from a 3-operation stub into a realistic API-key market data platform used by LynxCapital for FX rates, streaming ticks, OHLC candles, ECB reference fixings, and subscription management.
- Enriches the `instruments()` generator from 4-field, 10-pair output to 15 FX pairs each carrying 25 industry-standard fields (base/quote, assetClass, exchange, venue, tradingHours, liquidityTier, pipSize, lotSize, dayOpen/High/Low, prevClose, change, changePct). JPY pairs use correct 2-decimal pip quoting.
- Adds 5 new operations (get_ohlc, get_reference_rates, create_subscription, list_subscriptions, delete_subscription) and enriches existing tick output with timestamp, session label, intraday OHLC, volume, and change metrics.
- Adds 24 provider-specific tests; all 88 providerlab tests pass.

## Related Issue

Closes #237

## Type of Change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [x] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [x] Local run
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes:

- All 88 `test_providerlab.py` tests pass with `PROVIDERLAB_FAST=1`.
- All 15 `test_wiring.py` tests continue to pass; `get_market_snapshot` and the SSE consumer in `streams.py` are fully backward-compatible.
- New tests cover: API key accept/reject, instrument schema fields, filter by liquidityTier, snapshot field constraints, JPY pip precision, unknown symbol 404, stream_rates count clamping, OHLC across all 6 intervals, OHLC limit clamping, reference rate schema and per-date determinism, subscription full lifecycle, double-cancel 409, and SSE stream delivery.

## Research: Real-World API-Key Market Data Providers Consulted

The following platforms were used as reference for authentication behavior, schema design, naming conventions, and streaming patterns:

| Provider | Auth | Influences |
|---|---|---|
| **Polygon.io** | API Key (header) | Snapshot schema (`o/h/l/c/v`), session labels, subscription model |
| **Twelve Data** | API Key (header) | OHLC interval naming (`1min`, `1h`, `1day`), instrument reference fields |
| **Alpha Vantage** | API Key (query) | FX quote fields (`bid`, `ask`, `mid`, `change_pct`) |
| **ECB Data Portal** | None / API Key | Daily reference fixing format, `baseCurrency`, `publishedAt` shape |
| **LSEG/Refinitiv** | API Key | `liquidityTier`, `venue`, `pipSize`, `lotSize`, `tradingHours` naming |

All naming follows industry conventions, not Caracal-internal shapes.

## Changes

### `_mock/providerlab/data/generators.py`

- `instruments()`: replaces the old 10-pair, 4-field stub with 15 FX pairs each seeded with realistic nominal mids, correct pip sizes, deterministic day range, and 25 wire fields. JPY pairs use `pip_size=0.01` and 2-decimal quoting throughout.

### `_mock/providerlab/providers/pulse_market.py`

- `_tick()`: adds `timestamp` (ISO UTC), `change`, `changePct`, `volume`, `session`, `open`, `high`, `low`.
- `get_ohlc`: 1m/5m/15m/1h/4h/1d OHLC candles; `t/o/h/l/c/v` schema; `from`/`to` envelope; limit capped at 100.
- `get_reference_rates`: ECB-style daily fixings for 9 major EUR pairs; deterministic per `date` parameter; `source`, `publishedAt`, `baseCurrency` fields.
- `create_subscription` / `list_subscriptions` / `delete_subscription`: full subscription CRUD; 409 on double-cancel; cancelled subs excluded from the active listing.
- `seed()`: initialises `subscriptions` and `reference_date` tables.

### `_mock/providerlab/catalog.py`

Updated `pulse-market` entry: resources expanded to include `ohlc`, `reference_rates`, `subscriptions`; all 8 operations listed.

### `examples/lynxCapital/tests/test_providerlab.py`

24 new tests in a dedicated `# Pulse Market Data` section.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

## Screenshots of test 
<img width="729" height="436" alt="image" src="https://github.com/user-attachments/assets/0d4dbf70-8ba2-4f54-8bdf-1af14e90cd22" />




## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed