### PR TITLE
Tiered merge policy: admins, maintainers, contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# All changes require review and approval from the leadership team
-* @rawx18
+# Maintainers listed here review and approve contributor pull requests
+* @rawx18 @slo-pix

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -135,12 +135,13 @@ Pull requests run the same style gate automatically for changed primary-language
 
 ## Code Review
 
-Every change is proposed as a pull request and reviewed before it is merged or released.
+Changes are proposed against `main`, and the review required to merge depends on the contributor's role.
 
 ### How review is conducted
 
-- Open a pull request against `main`; direct pushes to `main` are not used for code changes.
-- At least one maintainer **other than the author** must review and approve the pull request before it is merged. Authors must not approve or merge their own changes.
+- Codeowners listed in `.github/CODEOWNERS` may push directly to `main`.
+- Maintainers in the `Caracal OSS Maintainers` team open a pull request but may merge it without a separate approving review.
+- All other contributors open a pull request that requires at least one approving review before it is merged. Authors must not approve or merge their own changes.
 - Area owners in `.github/CODEOWNERS` are requested automatically and own review for their paths.
 - Release publishing requires `release-approval` from a maintainer other than the one who prepared the release.
 
@@ -155,7 +156,7 @@ Every change is proposed as a pull request and reviewed before it is merged or r
 
 ### What is required to be acceptable
 
-A pull request is acceptable to merge only when it has at least one approving review from a non-author maintainer, all required CI checks pass, review comments are resolved, and the change is judged a worthwhile improvement free of known defects that would argue against inclusion.
+A contributor pull request is acceptable to merge only when it has at least one approving review, all required CI checks pass, review comments are resolved, and the change is judged a worthwhile improvement free of known defects that would argue against inclusion. Maintainers and codeowners are trusted to hold the changes they merge directly to the same standard.
 
 ## Releases
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -139,10 +139,10 @@ Changes are proposed against `main`, and the review required to merge depends on
 
 ### How review is conducted
 
-- Codeowners listed in `.github/CODEOWNERS` may push directly to `main`.
-- Maintainers in the `Caracal OSS Maintainers` team open a pull request but may merge it without a separate approving review.
-- All other contributors open a pull request that requires at least one approving review before it is merged. Authors must not approve or merge their own changes.
-- Area owners in `.github/CODEOWNERS` are requested automatically and own review for their paths.
+- Repository admins may push directly to `main`.
+- Maintainers listed in `.github/MAINTAINERS` open a pull request but may merge it without a separate approving review.
+- All other contributors open a pull request that requires at least one approving review from a maintainer before it is merged. Authors must not approve or merge their own changes.
+- Maintainers are listed in `.github/CODEOWNERS`, so they are requested automatically and their approval is required to merge a contributor pull request.
 - Release publishing requires `release-approval` from a maintainer other than the one who prepared the release.
 
 ### What reviewers must check
@@ -156,7 +156,7 @@ Changes are proposed against `main`, and the review required to merge depends on
 
 ### What is required to be acceptable
 
-A contributor pull request is acceptable to merge only when it has at least one approving review, all required CI checks pass, review comments are resolved, and the change is judged a worthwhile improvement free of known defects that would argue against inclusion. Maintainers and codeowners are trusted to hold the changes they merge directly to the same standard.
+A contributor pull request is acceptable to merge only when it has at least one approving review from a maintainer, all required CI checks pass, review comments are resolved, and the change is judged a worthwhile improvement free of known defects that would argue against inclusion. Maintainers and admins are trusted to hold the changes they merge directly to the same standard.
 
 ## Releases
 


### PR DESCRIPTION
## Summary
Aligns repository docs and ownership with the branch ruleset (`16090929`) governing `main`. Three tiers:

| Tier | Who | Behavior | Ruleset mechanism |
|---|---|---|---|
| **Admins** | repo admins | push directly to `main`, merge without review | `RepositoryRole: Admin` bypass `always` |
| **Maintainers** | the users in `.github/MAINTAINERS` (`@rawx18`, `@slo-pix`) | must open a PR, may merge **without review** | `User` bypass `pull_request` (individual users, **not** a GitHub team) |
| **Contributors** | everyone else | PR + **≥1 maintainer approval** | base `pull_request` rule with `require_code_owner_review: true` |

## Changes
- `.github/CODEOWNERS` → lists the **maintainers** (`* @rawx18 @slo-pix`). They are auto-requested as reviewers and their approval is required to merge a contributor PR.
- `.github/CONTRIBUTING.md` → Code Review section rewritten to describe the three tiers; drops the previous "every change needs a non-author maintainer review" wording and the GitHub-team reference.

## Enforcement (already applied to the live ruleset)
- bypass: `RepositoryRole: Admin` (always); `User: RAWx18`, `User: Slo-Pix` (pull_request)
- `pull_request` rule: `require_code_owner_review: true`, `required_approving_review_count: 1`, stale-review dismissal, last-push approval, thread resolution.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated contribution guidelines with clearer, role-based rules for proposing and merging changes, including when admins and maintainers can merge directly and how reviewer approvals work for other contributors.
- Expanded the merge “acceptable” checklist to require at least one approving maintainer review, successful required CI checks, resolved review comments, and an explicit quality/defect-free assessment.  
- Updated pull request ownership rules in the CODEOWNERS configuration to reflect new required approvers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->