### PR TITLE
chore(playbooks): align Codex mapping output with claude-code and copilot

### DIFF
--- a/playbooks/mapping/openai-codex/.codex/skills/ui-schema-translation/SKILL.md
+++ b/playbooks/mapping/openai-codex/.codex/skills/ui-schema-translation/SKILL.md
@@ -7,7 +7,7 @@ Use to translate UI labels, helper text, placeholders, and provider terminology 
 1. Collect exact UI labels, helper text, placeholders, and section headings.
 2. Match labels to `.codex/console-fields.ground-truth.json`.
 3. Preserve provider terminology when explaining provider-side setup.
-4. Output `UI label -> Caracal field -> meaning -> expected value`.
+4. Output `UI label -> Caracal Console field -> meaning -> expected value`.
 5. Ask for exact labels when a field is ambiguous.
 
 Never expose internal Caracal keys.

--- a/playbooks/mapping/openai-codex/AGENTS.md
+++ b/playbooks/mapping/openai-codex/AGENTS.md
@@ -6,7 +6,7 @@ You help users map external provider and resource dashboard labels to visible Ca
 
 - Treat every task as UI field mapping first.
 - Prioritize truthfulness over completion theater.
-- Map `UI label -> Caracal field -> meaning -> expected value`.
+- Map `UI label -> Caracal Console field -> meaning -> expected value`.
 - Use `.codex/console-fields.ground-truth.json` as the Console field ground truth.
 - Do not expose internal Caracal keys or codebase-only details.
 - If Console lacks the provider type or field the provider requires, say it is unsupported and send the user to `https://github.com/Garudex-Labs/caracal/issues/new/choose`.
@@ -42,6 +42,13 @@ Ask for visible resource form fields, provider binding, scopes, upstream target,
 
 Map each resource field individually. Keep target and routing values on the resource. Keep upstream credential values on the provider.
 
+## Field Boundary
+
+- Provider = which upstream credential or auth flow Gateway attaches.
+- Resource = what is protected, which scopes are allowed, and where Gateway sends traffic.
+- If a value is both provider-related and resource-related, explain the split briefly and put each value in the correct Console area.
+- If the user asks about grants, policies, or SDK code, redirect to the Provider or Resource fields needed for the current mapping task.
+
 ## Secret handling
 
 - Never reveal raw secrets, tokens, API keys, private keys, client secrets, or provider credentials.
@@ -62,17 +69,18 @@ Examples:
 Use this format for each field:
 
 - UI label:
-- Caracal field:
+- Caracal Console field:
+- Belongs to: Provider or Resource
 - Meaning:
 - Required or optional:
 - Expected value:
-- Notes:
+- Notes: concise mapping reason, validation note, or docs status
 - Secret handling:
 
 For unsupported needs:
 
 - Unsupported need:
-- Provider requirement:
+- Provider or resource requirement:
 - Current Caracal Console support:
 - What to do:
 - Issue link: `https://github.com/Garudex-Labs/caracal/issues/new/choose`


### PR DESCRIPTION
## Summary

- Small cosmetic uniformity pass on the OpenAI Codex mapping playbook so the three mapping playbooks (claude-code, copilot, codex) describe Provider/Resource boundaries and emit mapping output the same way
- Follow-up to PR #249 (Claude Code) and PR #250 (Codex), per @RAWx18's uniformity comment on PR #249
- Companion to the GitHub Copilot tightening in #263

## Changes

- `AGENTS.md` mission and mapping output now use `Caracal Console field` (matching claude-code and copilot)
- Mapping output gains a `Belongs to: Provider or Resource` row
- New `Field Boundary` section briefly states what Provider and Resource each own (mirrors claude-code)
- Unsupported-needs template uses `Provider or resource requirement`
- `ui-schema-translation` skill uses `Caracal Console field` in its output template

## Scope

Pure cosmetic uniformity. No new agents, skills, or workflows. Mohammad-Ali-Haider's tightening in PR #250 stays intact; this only adjusts vocabulary and adds one short section so the playbooks read uniformly.

## Test plan

- [x] Skim diff for vocabulary parity with `playbooks/mapping/claude-code/CLAUDE.md`
- [x] Confirm Codex still loads `AGENTS.md` and the unchanged skills/agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified field naming conventions across mapping documentation for improved consistency.
  * Enhanced mapping output template with additional fields, structured notes section, and explicit handling of unsupported requirements.
  * Added detailed field boundary definitions to distinguish between Provider and Resource categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->