### PR TITLE
fix(gateway): generate traceparent independently of request ids

### DIFF
--- a/services/gateway/internal/audit.go
+++ b/services/gateway/internal/audit.go
@@ -21,6 +21,7 @@ type auditEmitter interface {
 
 type gatewayAuditInput struct {
 	RequestID          string
+	TraceID            string
 	ZoneID             string
 	ApplicationID      string
 	Resource           string
@@ -51,6 +52,9 @@ func gatewayActionEvent(input gatewayAuditInput) (audit.Event, error) {
 		"method":              input.Method,
 		"gateway_status":      input.GatewayStatus,
 		"latency_ms":          input.Latency.Milliseconds(),
+	}
+	if input.TraceID != "" {
+		meta["trace_id"] = input.TraceID
 	}
 	if input.UpstreamHost != "" {
 		meta["upstream_host"] = input.UpstreamHost

--- a/services/gateway/internal/proxy.go
+++ b/services/gateway/internal/proxy.go
@@ -335,6 +335,9 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	traceID := traceIDFromTraceparent(upstreamReq.Header.Get("Traceparent"))
+	logger = logger.With().Str("trace_id", traceID).Logger()
+
 	start := time.Now()
 	resp, err := p.client.Do(upstreamReq)
 	latency := time.Since(start)
@@ -345,6 +348,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Error().Err(err).Int("status", status).Msg("upstream request failed")
 		p.emitActionAudit(gatewayAuditInput{
 			RequestID:          requestID,
+			TraceID:            traceID,
 			ZoneID:             bind.ZoneID,
 			ApplicationID:      bind.ApplicationID,
 			Resource:           resource,
@@ -371,6 +375,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.metrics.RequestsAllowed.Add(1)
 	p.emitActionAudit(gatewayAuditInput{
 		RequestID:          requestID,
+		TraceID:            traceID,
 		ZoneID:             bind.ZoneID,
 		ApplicationID:      bind.ApplicationID,
 		Resource:           resource,
@@ -508,7 +513,10 @@ func buildUpstreamRequest(r *http.Request, upstreamURL *url.URL, caracalToken st
 		req.Header.Set(authHeader, scheme+" "+caracalToken)
 	}
 	req.Header.Set("X-Request-Id", requestID)
-	if req.Header.Get("Traceparent") == "" {
+	// The gateway is a trust boundary: a caller-supplied Traceparent is forwarded only
+	// when it is a parseable W3C value, otherwise it is replaced so malformed tracing
+	// context never propagates upstream.
+	if !validTraceparent(req.Header.Get("Traceparent")) {
 		req.Header.Set("Traceparent", newTraceparent())
 	}
 

--- a/services/gateway/internal/proxy.go
+++ b/services/gateway/internal/proxy.go
@@ -509,7 +509,7 @@ func buildUpstreamRequest(r *http.Request, upstreamURL *url.URL, caracalToken st
 	}
 	req.Header.Set("X-Request-Id", requestID)
 	if req.Header.Get("Traceparent") == "" {
-		req.Header.Set("Traceparent", traceparentFromRequestID(requestID))
+		req.Header.Set("Traceparent", newTraceparent())
 	}
 
 	// Replace, never append: the gateway is a trust boundary and any caller-supplied
@@ -710,16 +710,4 @@ func writeErr(w http.ResponseWriter, requestID string, status int, code shareder
 	w.Header().Set("X-Request-Id", requestID)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(e)
-}
-
-// traceparentFromRequestID builds a W3C traceparent value seeded from the request id
-// so a single trace identifier flows from the gateway through to upstream provider hops.
-func traceparentFromRequestID(requestID string) string {
-	hex := strings.ReplaceAll(requestID, "-", "")
-	for len(hex) < 32 {
-		hex += "0"
-	}
-	traceID := hex[:32]
-	spanID := hex[:16]
-	return "00-" + traceID + "-" + spanID + "-01"
 }

--- a/services/gateway/internal/safety.go
+++ b/services/gateway/internal/safety.go
@@ -239,6 +239,26 @@ func newRequestID() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
+// newTraceparent returns a standards-compliant W3C traceparent header value.
+// It is generated independently from X-Request-Id because request IDs are
+// allowed to be human-friendly opaque strings rather than lowercase hex.
+func newTraceparent() string {
+	var ids [24]byte
+	if _, err := rand.Read(ids[:]); err != nil {
+		// Fall back to hash-derived bytes so trace propagation stays valid even if
+		// randomness is temporarily unavailable.
+		sum := sha256.Sum256([]byte(newRequestID()))
+		copy(ids[:], sum[:24])
+	}
+	if zeroBytes(ids[:16]) {
+		ids[0] = 1
+	}
+	if zeroBytes(ids[16:24]) {
+		ids[16] = 1
+	}
+	return "00-" + hex.EncodeToString(ids[:16]) + "-" + hex.EncodeToString(ids[16:24]) + "-01"
+}
+
 // validRequestID accepts UUID-shaped or short opaque identifiers (≤128 chars, printable ASCII).
 func validRequestID(s string) bool {
 	if s == "" || len(s) > 128 {
@@ -246,6 +266,15 @@ func validRequestID(s string) bool {
 	}
 	for _, r := range s {
 		if r < 0x21 || r > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func zeroBytes(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
 			return false
 		}
 	}

--- a/services/gateway/internal/safety.go
+++ b/services/gateway/internal/safety.go
@@ -281,6 +281,59 @@ func zeroBytes(b []byte) bool {
 	return true
 }
 
+// validTraceparent reports whether s is a parseable W3C traceparent. A version-00
+// value must carry exactly the four canonical fields; higher versions may append
+// fields, so their leading fields are parsed and the rest preserved rather than
+// discarded. trace-id and parent-id must be non-zero lowercase hex of fixed width.
+func validTraceparent(s string) bool {
+	parts := strings.Split(s, "-")
+	if len(parts) < 4 {
+		return false
+	}
+	version, traceID, parentID, flags := parts[0], parts[1], parts[2], parts[3]
+	if len(version) != 2 || !isHex(version) || version == "ff" {
+		return false
+	}
+	if version == "00" && len(parts) != 4 {
+		return false
+	}
+	if len(traceID) != 32 || !isHex(traceID) || allZeroHex(traceID) {
+		return false
+	}
+	if len(parentID) != 16 || !isHex(parentID) || allZeroHex(parentID) {
+		return false
+	}
+	return len(flags) == 2 && isHex(flags)
+}
+
+// traceIDFromTraceparent returns the trace-id field that correlates every hop of a
+// request, used to tie gateway access logs and audit events to the distributed trace.
+func traceIDFromTraceparent(s string) string {
+	parts := strings.Split(s, "-")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return s != ""
+}
+
+func allZeroHex(s string) bool {
+	for _, c := range s {
+		if c != '0' {
+			return false
+		}
+	}
+	return true
+}
+
 // tokenFingerprint returns a short SHA-256 hex prefix for a bearer token.
 // The full token is never logged or returned anywhere.
 func tokenFingerprint(token string) string {

--- a/tests/source/go/services/gateway/internal/traceparent_test.go
+++ b/tests/source/go/services/gateway/internal/traceparent_test.go
@@ -98,6 +98,97 @@ func TestBuildUpstreamRequestPreservesInboundTraceparent(t *testing.T) {
 	}
 }
 
+func TestValidTraceparent(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+		// A higher version may append fields; the leading fields still parse.
+		"01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra",
+	}
+	for _, tp := range valid {
+		if !validTraceparent(tp) {
+			t.Errorf("validTraceparent(%q) = false, want true", tp)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"customer_request_42",
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",      // missing flags
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-x", // version 00 with trailing field
+		"00-00000000000000000000000000000000-00f067aa0ba902b7-01",   // zero trace-id
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",   // zero parent-id
+		"00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01",   // uppercase hex
+		"00-4bf92f3577b34da6-00f067aa0ba902b7-01",                   // short trace-id
+		"ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",   // reserved version
+	}
+	for _, tp := range invalid {
+		if validTraceparent(tp) {
+			t.Errorf("validTraceparent(%q) = true, want false", tp)
+		}
+	}
+}
+
+func TestTraceIDFromTraceparent(t *testing.T) {
+	t.Parallel()
+
+	got := traceIDFromTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	if want := "4bf92f3577b34da6a3ce929d0e0e4736"; got != want {
+		t.Errorf("traceIDFromTraceparent = %q, want %q", got, want)
+	}
+}
+
+func TestBuildUpstreamRequestRegeneratesMalformedInboundTraceparent(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://gateway.example.com/v1/messages", nil)
+	req.Header.Set("Traceparent", "customer_request_42")
+
+	upstreamReq, err := buildUpstreamRequest(
+		req,
+		mustParseURL(t, "https://api.example.com"),
+		"caracal-token",
+		corests.UpstreamDirective{},
+		http.NoBody,
+		"customer_request_42",
+	)
+	if err != nil {
+		t.Fatalf("buildUpstreamRequest: %v", err)
+	}
+	got := upstreamReq.Header.Get("Traceparent")
+	if got == "customer_request_42" {
+		t.Fatal("malformed inbound Traceparent was forwarded unchanged")
+	}
+	if !traceparentPattern.MatchString(got) {
+		t.Fatalf("regenerated Traceparent %q does not match W3C format", got)
+	}
+}
+
+func TestBuildUpstreamRequestPreservesFutureVersionTraceparent(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://gateway.example.com/v1/messages", nil)
+	want := "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra"
+	req.Header.Set("Traceparent", want)
+
+	upstreamReq, err := buildUpstreamRequest(
+		req,
+		mustParseURL(t, "https://api.example.com"),
+		"caracal-token",
+		corests.UpstreamDirective{},
+		http.NoBody,
+		"customer_request_42",
+	)
+	if err != nil {
+		t.Fatalf("buildUpstreamRequest: %v", err)
+	}
+	if got := upstreamReq.Header.Get("Traceparent"); got != want {
+		t.Fatalf("Traceparent = %q, want %q", got, want)
+	}
+}
+
 func mustParseURL(t *testing.T, raw string) *url.URL {
 	t.Helper()
 	u, err := url.Parse(raw)

--- a/tests/source/go/services/gateway/internal/traceparent_test.go
+++ b/tests/source/go/services/gateway/internal/traceparent_test.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Tests for request-id and traceparent propagation invariants.
+
+package internal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+
+	corests "github.com/garudex-labs/caracal/packages/core/go/sts"
+)
+
+var traceparentPattern = regexp.MustCompile(`^00-[0-9a-f]{32}-[0-9a-f]{16}-01$`)
+
+func TestNewTraceparent(t *testing.T) {
+	t.Parallel()
+
+	a := newTraceparent()
+	b := newTraceparent()
+	if a == b {
+		t.Error("traceparents collided")
+	}
+	for _, got := range []string{a, b} {
+		if !traceparentPattern.MatchString(got) {
+			t.Fatalf("traceparent %q does not match W3C format", got)
+		}
+	}
+}
+
+func TestRequestIDMiddlewarePreservesOpaqueIDs(t *testing.T) {
+	t.Parallel()
+
+	want := "customer_request_42"
+	var captured string
+	h := requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = requestIDFromContext(r.Context())
+	}))
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-Id", want)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if captured != want {
+		t.Errorf("got %q, want %q", captured, want)
+	}
+	if w.Header().Get("X-Request-Id") != want {
+		t.Errorf("response X-Request-Id = %q, want %q", w.Header().Get("X-Request-Id"), want)
+	}
+}
+
+func TestBuildUpstreamRequestGeneratesValidTraceparentForOpaqueRequestID(t *testing.T) {
+	t.Parallel()
+
+	upstreamReq, err := buildUpstreamRequest(
+		httptest.NewRequest(http.MethodPost, "https://gateway.example.com/v1/messages?foo=bar", nil),
+		mustParseURL(t, "https://api.example.com/base"),
+		"caracal-token",
+		corests.UpstreamDirective{},
+		http.NoBody,
+		"customer_request_42",
+	)
+	if err != nil {
+		t.Fatalf("buildUpstreamRequest: %v", err)
+	}
+	got := upstreamReq.Header.Get("Traceparent")
+	if !traceparentPattern.MatchString(got) {
+		t.Fatalf("Traceparent %q does not match W3C format", got)
+	}
+	if upstreamReq.Header.Get("X-Request-Id") != "customer_request_42" {
+		t.Fatalf("X-Request-Id = %q, want opaque request id preserved", upstreamReq.Header.Get("X-Request-Id"))
+	}
+}
+
+func TestBuildUpstreamRequestPreservesInboundTraceparent(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://gateway.example.com/v1/messages", nil)
+	want := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	req.Header.Set("Traceparent", want)
+
+	upstreamReq, err := buildUpstreamRequest(
+		req,
+		mustParseURL(t, "https://api.example.com"),
+		"caracal-token",
+		corests.UpstreamDirective{},
+		http.NoBody,
+		"customer_request_42",
+	)
+	if err != nil {
+		t.Fatalf("buildUpstreamRequest: %v", err)
+	}
+	if got := upstreamReq.Header.Get("Traceparent"); got != want {
+		t.Fatalf("Traceparent = %q, want %q", got, want)
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", raw, err)
+	}
+	return u
+}


### PR DESCRIPTION
## Summary
- stop deriving `Traceparent` from `X-Request-Id` in the gateway fallback path
- generate a standards-compliant W3C `Traceparent` independently when one is missing
- add regression coverage in the mirrored Go source-test tree for opaque request IDs and traceparent propagation

## Problem
The gateway accepted broad printable `X-Request-Id` values and reused them to synthesize a W3C `Traceparent` header. Opaque request IDs such as `customer_request_42` are valid for human-readable log correlation, but they are not valid trace/span ID material because `Traceparent` requires strict lowercase hex identifiers.

That could produce malformed trace headers and break distributed tracing even though request handling still succeeded.

## Where It Breaks
This breaks when all of the following are true:
- a caller sends a custom `X-Request-Id`
- the value is accepted by the gateway as a valid request id
- the value is not valid lowercase hex / trace-id material
- the inbound request does not already include a `Traceparent`
- the gateway proxies the request upstream

Example:
- inbound `X-Request-Id: customer_request_42`
- gateway preserves that request id for logs
- gateway previously tried to derive `Traceparent` from that same value
- the resulting `Traceparent` was malformed because `_` and other allowed request-id characters are not valid in W3C trace/span identifiers

In practice this can cause:
- tracing libraries or proxies to reject or ignore the propagated `Traceparent`
- the upstream hop to start a new unrelated trace instead of continuing the gateway trace
- broken trace correlation between gateway and downstream systems
- reduced observability during debugging or incident response

## Fix
- preserve `X-Request-Id` as the human-readable correlation id
- generate a fresh compliant `Traceparent` value independently when the inbound request does not provide one
- preserve an inbound `Traceparent` if already present

## Testing
- ran the repo's CI-style Go source test helper:
  - `scripts/runGoSourceTests.sh 'C:\Program Files\Go\bin\go.exe' test ./services/gateway/...`
- result:
  - `ok github.com/garudex-labs/caracal/gateway/cmd/gateway`
  - `ok github.com/garudex-labs/caracal/gateway/internal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request tracing with standards-compliant trace propagation to upstream services.
  * Treats the incoming trace header as a trust boundary: invalid values are regenerated to prevent malformed/all-zero traces.
  * Ensures trace identifiers are included in emitted audit event metadata when available.
  * Preserves inbound request IDs and valid trace headers more consistently through gateway processing.
* **Tests**
  * Added/expanded coverage for trace header formatting/validation, request ID propagation, and trace ID extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->