### PR TITLE
fix(web): verify clipboard write before confirming copy (#281)

### DIFF
--- a/apps/web/src/components/console/ResourceWorkspace.tsx
+++ b/apps/web/src/components/console/ResourceWorkspace.tsx
@@ -19,6 +19,7 @@ import {
   SearchInput,
   Select,
   Skeleton,
+  useCopyToClipboard,
   type Column,
   type Crumb,
   type FilterGroup,
@@ -408,6 +409,7 @@ export function Mono({ children }: { children: ReactNode }) {
 // operators routinely copy out of a detail panel. The value sits in a subtle field and the
 // copy button is a clearly bordered control that never overlaps the text.
 export function CopyValue({ value, mono = true }: { value: string; mono?: boolean }) {
+  const copy = useCopyToClipboard();
   const [copied, setCopied] = useState(false);
   return (
     <span className="flex min-w-0 max-w-full items-stretch gap-1.5">
@@ -423,11 +425,14 @@ export function CopyValue({ value, mono = true }: { value: string; mono?: boolea
         type="button"
         aria-label={copied ? "Copied" : "Copy"}
         title={copied ? "Copied" : "Copy"}
-        onClick={() => {
-          void navigator.clipboard?.writeText(value);
-          setCopied(true);
-          window.setTimeout(() => setCopied(false), 1200);
-        }}
+        onClick={() =>
+          void copy(value, {
+            onSuccess: () => {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1200);
+            },
+          })
+        }
         className={cx(
           "grid h-6 w-6 flex-shrink-0 place-items-center self-start rounded border outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/40",
           copied

--- a/apps/web/src/components/ui/clipboard.ts
+++ b/apps/web/src/components/ui/clipboard.ts
@@ -1,0 +1,45 @@
+/*
+Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+Caracal, a product of Garudex Labs
+
+This file provides the shared clipboard copy hook used across the Console UI.
+*/
+import { useCallback } from "react";
+
+import { useToast } from "./toastContext";
+
+interface CopyOptions {
+  successTitle?: string;
+  onSuccess?: () => void;
+}
+
+async function writeClipboard(text: string): Promise<boolean> {
+  if (!navigator.clipboard) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Confirms success only after the clipboard write resolves, so the user is never told a value was
+// copied when the clipboard was unavailable or the write was denied.
+export function useCopyToClipboard(): (text: string, opts?: CopyOptions) => Promise<void> {
+  const toast = useToast();
+  return useCallback(
+    async (text, opts) => {
+      if (await writeClipboard(text)) {
+        if (opts?.onSuccess) opts.onSuccess();
+        else toast({ tone: "success", title: opts?.successTitle ?? "Copied" });
+      } else {
+        toast({
+          tone: "error",
+          title: "Copy failed",
+          description: "Copy it manually instead.",
+        });
+      }
+    },
+    [toast],
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -10,6 +10,7 @@ export * from "./ConfirmDialog";
 export * from "./ViewOnly";
 export * from "./Toast";
 export * from "./toastContext";
+export * from "./clipboard";
 export * from "./Tooltip";
 export * from "./Tabs";
 export * from "./Breadcrumbs";

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.agents.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.agents.tsx
@@ -28,6 +28,7 @@ import {
   Select,
   Skeleton,
   Spinner,
+  useCopyToClipboard,
   useToast,
   type Column,
 } from "@/components/ui";
@@ -602,12 +603,7 @@ function AgentInspector({
   const terminal = agent.status === "terminated";
   const metadata = agent.metadata ?? {};
   const live = liveness(agent);
-  const toast = useToast();
-
-  function copy(value: string, label: string) {
-    void navigator.clipboard?.writeText(value);
-    toast({ tone: "success", title: `${label} copied` });
-  }
+  const copy = useCopyToClipboard();
 
   return (
     <div className="flex flex-col gap-6">
@@ -666,7 +662,7 @@ function AgentInspector({
       <DetailGroup title="Identity">
         <DetailField label="Agent session">
           <button
-            onClick={() => copy(agent.agent_session_id, "Session ID")}
+            onClick={() => void copy(agent.agent_session_id, { successTitle: "Session ID copied" })}
             className="text-left hover:underline"
           >
             <Mono>{agent.agent_session_id}</Mono>

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.applications.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.applications.tsx
@@ -25,6 +25,7 @@ import {
   Field,
   IdentityAvatar,
   Modal,
+  useCopyToClipboard,
   useToast,
   type Column,
 } from "@/components/ui";
@@ -567,6 +568,8 @@ function SecretModal({
   onClose: () => void;
   onCopied: () => void;
 }) {
+  const copy = useCopyToClipboard();
+
   return (
     <Modal
       open={secret !== null}
@@ -585,10 +588,7 @@ function SecretModal({
             <Button
               variant="secondary"
               size="sm"
-              onClick={() => {
-                void navigator.clipboard?.writeText(secret.clientSecret);
-                onCopied();
-              }}
+              onClick={() => void copy(secret.clientSecret, { onSuccess: onCopied })}
             >
               Copy
             </Button>

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.audit.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.audit.tsx
@@ -21,6 +21,7 @@ import {
   Field,
   Select,
   Skeleton,
+  useCopyToClipboard,
   type Column,
   type FilterGroup,
 } from "@/components/ui";
@@ -569,16 +570,20 @@ function AuditFilterBar({
 // Copies the raw backend payload to the clipboard so operators can paste full audit
 // evidence into tickets.
 function CopyJsonButton({ value, label = "Copy JSON" }: { value: unknown; label?: string }) {
+  const copy = useCopyToClipboard();
   const [copied, setCopied] = useState(false);
   return (
     <Button
       variant="secondary"
       size="sm"
-      onClick={() => {
-        void navigator.clipboard?.writeText(JSON.stringify(value, null, 2));
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1200);
-      }}
+      onClick={() =>
+        void copy(JSON.stringify(value, null, 2), {
+          onSuccess: () => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1200);
+          },
+        })
+      }
     >
       {copied ? "Copied" : label}
     </Button>

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.control.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.control.tsx
@@ -24,6 +24,7 @@ import {
   InfoHint,
   Modal,
   Tabs,
+  useCopyToClipboard,
   useToast,
   type Column,
 } from "@/components/ui";
@@ -516,7 +517,7 @@ function ControlSecretModal({
   secret: { id: string; name: string; secret: string } | null;
   onClose: () => void;
 }) {
-  const toast = useToast();
+  const copy = useCopyToClipboard();
   return (
     <Modal
       open={secret !== null}
@@ -543,10 +544,7 @@ function ControlSecretModal({
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => {
-                  void navigator.clipboard?.writeText(secret.secret);
-                  toast({ tone: "success", title: "Secret copied" });
-                }}
+                onClick={() => void copy(secret.secret, { successTitle: "Secret copied" })}
               >
                 Copy
               </Button>
@@ -809,7 +807,7 @@ function TokenResultModal({
   result: ControlTokenResult | null;
   onClose: () => void;
 }) {
-  const toast = useToast();
+  const copy = useCopyToClipboard();
   return (
     <Modal
       open={result !== null}
@@ -840,10 +838,7 @@ function TokenResultModal({
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => {
-                  void navigator.clipboard?.writeText(result.accessToken);
-                  toast({ tone: "success", title: "Token copied" });
-                }}
+                onClick={() => void copy(result.accessToken, { successTitle: "Token copied" })}
               >
                 Copy
               </Button>
@@ -890,6 +885,7 @@ function SettingsTab() {
 
 function EndpointStatusBar() {
   const toast = useToast();
+  const copy = useCopyToClipboard();
   const statusQuery = useControlStatus();
   const enable = useEnableControl();
   const disable = useDisableControl();
@@ -963,10 +959,7 @@ function EndpointStatusBar() {
           </div>
           {url ? (
             <button
-              onClick={() => {
-                void navigator.clipboard?.writeText(url);
-                toast({ tone: "success", title: "Copied" });
-              }}
+              onClick={() => void copy(url)}
               className="shrink-0 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               Copy
@@ -1311,17 +1304,14 @@ function Panel({ title, children }: { title: string; children: ReactNode }) {
 }
 
 function CodeBlock({ code, lang }: { code: string; lang: string }) {
-  const toast = useToast();
+  const copy = useCopyToClipboard();
   return (
     <div className="group relative">
       <pre className="scrollbar-thin overflow-x-auto bg-[#0d1117] p-3 font-mono text-xs leading-relaxed text-[#e6edf3]">
         {highlightCode(code, lang, TERMINAL_HIGHLIGHT)}
       </pre>
       <button
-        onClick={() => {
-          void navigator.clipboard?.writeText(code);
-          toast({ tone: "success", title: "Copied" });
-        }}
+        onClick={() => void copy(code)}
         className="absolute right-2 top-2 rounded border border-white/15 bg-white/5 px-2 py-1 text-[10px] font-medium text-white/70 opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover:opacity-100"
       >
         Copy

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.providers.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.providers.tsx
@@ -27,6 +27,7 @@ import {
   Modal,
   Select,
   Spinner,
+  useCopyToClipboard,
   useToast,
   type Column,
   type FilterGroup,
@@ -363,7 +364,7 @@ function ProviderDetail({
   onDelete: () => void;
   zoneId: string;
 }) {
-  const toast = useToast();
+  const copy = useCopyToClipboard();
   const secretKeys = new Set(provider.secret_config_keys);
   const configEntries = Object.entries(provider.config_json ?? {}).filter(
     ([key]) => !secretKeys.has(key as never),
@@ -378,10 +379,11 @@ function ProviderDetail({
             <Button
               variant="secondary"
               size="sm"
-              onClick={() => {
-                void navigator.clipboard?.writeText(JSON.stringify(provider, null, 2));
-                toast({ tone: "success", title: "Provider JSON copied" });
-              }}
+              onClick={() =>
+                void copy(JSON.stringify(provider, null, 2), {
+                  successTitle: "Provider JSON copied",
+                })
+              }
             >
               Copy JSON
             </Button>
@@ -626,7 +628,7 @@ function ConnectProviderModal({
   onClose: () => void;
   onConnected: () => void;
 }) {
-  const toast = useToast();
+  const copy = useCopyToClipboard();
   const resourcesQuery = useResources(zoneId);
   const authorize = useAuthorizeProviderGrant(zoneId);
   const [userId, setUserId] = useState("");
@@ -719,10 +721,7 @@ function ConnectProviderModal({
             <Button
               variant="secondary"
               size="sm"
-              onClick={() => {
-                void navigator.clipboard?.writeText(result.url);
-                toast({ tone: "success", title: "Link copied" });
-              }}
+              onClick={() => void copy(result.url, { successTitle: "Link copied" })}
             >
               Copy
             </Button>

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.sessions.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.sessions.tsx
@@ -15,7 +15,15 @@ import {
 } from "@/components/console/ResourceWorkspace";
 import { FeedToolbar } from "@/components/console/FeedToolbar";
 import { ZoneScopedPage } from "@/components/console/ZoneScope";
-import { Badge, Button, Field, Select, Tooltip, type Column } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  Field,
+  Select,
+  Tooltip,
+  useCopyToClipboard,
+  type Column,
+} from "@/components/ui";
 import { cx } from "@/lib/cx";
 import { ConsoleApiError } from "@/platform/api/client";
 import { useSessionsFeed } from "@/platform/api/hooks";
@@ -275,16 +283,20 @@ function SessionFilterBar({
 // structured panel, preserving the full backend record (including zone_id) for debugging
 // and sharing.
 function CopyJsonButton({ session }: { session: Session }) {
+  const copy = useCopyToClipboard();
   const [copied, setCopied] = useState(false);
   return (
     <Button
       variant="secondary"
       size="sm"
-      onClick={() => {
-        void navigator.clipboard?.writeText(JSON.stringify(session, null, 2));
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1200);
-      }}
+      onClick={() =>
+        void copy(JSON.stringify(session, null, 2), {
+          onSuccess: () => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1200);
+          },
+        })
+      }
     >
       {copied ? "Copied" : "Copy JSON"}
     </Button>


### PR DESCRIPTION
## Summary

Fixes #281. Console copy buttons reported success the instant they fired — `navigator.clipboard?.writeText(...)` was invoked with `void` and no rejection handling, then a success toast (or "Copied" state) ran unconditionally. When the clipboard is unavailable (non-secure context, older browser) or the write is denied, the user was told a value was copied when it was not. For a one-time client secret or Control access token, that means silently losing the credential.

Per the maintainer's guidance on the issue ("a shared clipboard helper is the preferred approach"), this introduces one shared helper and routes every copy affordance through it.

## Changes

- **New `useCopyToClipboard` hook** (`components/ui/clipboard.ts`, exported from the UI kit): checks clipboard support, awaits the write, and confirms success **only after it resolves**. On failure it raises an error toast; on success it either fires a success toast (`successTitle`) or runs a caller `onSuccess` (used by buttons that show an inline "Copied" checkmark).
- **Replaced all 9 raw `navigator.clipboard` call sites** with the hook:
  - Secrets/tokens: Applications client secret, Control client secret, Control access token
  - Links/snippets: Control endpoint URL, Control code blocks, provider connection link
  - JSON/identifiers: provider JSON, session JSON, audit payload, agent session ID, generic `CopyValue`
- Dead `useToast` imports removed where the component only used it for copy.

## Behavior

- Success toast / "Copied" state now appears **only** after a confirmed write.
- Unavailable or rejected clipboard → error toast ("Copy failed — Copy it manually instead."); the value stays visible in its field for manual selection.

## Verification

- `tsc --noEmit`: clean
- `eslint`: no new errors (only pre-existing `react-refresh` warnings in route files)
- `vite build`: succeeds

Clipboard runtime behavior requires a secure context + user gesture behind the auth-gated console, so it isn't exercised in CI; the change is a thin, traced wrapper and all static checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent copy-to-clipboard experience across the app for session IDs, secrets, URLs, code snippets, and JSON.

* **Bug Fixes**
  * Improved copy actions so success feedback appears only after a copy actually succeeds.
  * Added clearer feedback when copying fails, helping users know when to try manual copy instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->