### PR TITLE
fix(infra): isolate and clean up Helm validate temp artifacts (#299)

### DIFF
--- a/infra/helm/caracal/scripts/validate.sh
+++ b/infra/helm/caracal/scripts/validate.sh
@@ -10,44 +10,47 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 command -v helm >/dev/null 2>&1 || { echo "helm is required" >&2; exit 1; }
 
+DIR="$(mktemp -d)"
+trap 'rm -rf "${DIR}"' EXIT
+
 helm lint "${ROOT}"
-helm template caracal "${ROOT}" -f "${ROOT}/values.dev.yaml" >/tmp/caracal-helm-dev.yaml
-helm template caracal "${ROOT}" -f "${ROOT}/values.rc.yaml" >/tmp/caracal-helm-rc.yaml
+helm template caracal "${ROOT}" -f "${ROOT}/values.dev.yaml" >"${DIR}/dev.yaml"
+helm template caracal "${ROOT}" -f "${ROOT}/values.rc.yaml" >"${DIR}/rc.yaml"
 prod_set=(
     --set secrets.database.host=postgres-ha.caracal-platform.svc.cluster.local
     --set secrets.redis.host=redis-ha.caracal-platform.svc.cluster.local
 )
-helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" "${prod_set[@]}" >/tmp/caracal-helm-production.yaml
+helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" "${prod_set[@]}" >"${DIR}/production.yaml"
 
-helm template caracal "${ROOT}" -f "${ROOT}/examples/values.cloud-managed.yaml" >/tmp/caracal-helm-cloud.yaml
-grep -q "kind: Ingress" /tmp/caracal-helm-cloud.yaml || { echo "cloud overlay must render ingress" >&2; exit 1; }
-grep -q "kind: ServiceMonitor" /tmp/caracal-helm-cloud.yaml || { echo "cloud overlay must render ServiceMonitor" >&2; exit 1; }
+helm template caracal "${ROOT}" -f "${ROOT}/examples/values.cloud-managed.yaml" >"${DIR}/cloud.yaml"
+grep -q "kind: Ingress" "${DIR}/cloud.yaml" || { echo "cloud overlay must render ingress" >&2; exit 1; }
+grep -q "kind: ServiceMonitor" "${DIR}/cloud.yaml" || { echo "cloud overlay must render ServiceMonitor" >&2; exit 1; }
 
-if helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" >/tmp/caracal-helm-production-negative.yaml 2>/tmp/caracal-helm-production-negative.err; then
+if helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" >"${DIR}/production-negative.yaml" 2>"${DIR}/production-negative.err"; then
     echo "stable render with default Postgres/Redis hosts must fail" >&2
     exit 1
 fi
-grep -q "externally managed HA Postgres" /tmp/caracal-helm-production-negative.err
+grep -q "externally managed HA Postgres" "${DIR}/production-negative.err"
 
-if helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" --set secrets.database.host=postgres-ha.caracal-platform.svc.cluster.local >/tmp/caracal-helm-production-redis-negative.yaml 2>/tmp/caracal-helm-production-redis-negative.err; then
+if helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" --set secrets.database.host=postgres-ha.caracal-platform.svc.cluster.local >"${DIR}/production-redis-negative.yaml" 2>"${DIR}/production-redis-negative.err"; then
     echo "stable render with default Redis host must fail" >&2
     exit 1
 fi
-grep -q "externally managed HA Redis" /tmp/caracal-helm-production-redis-negative.err
+grep -q "externally managed HA Redis" "${DIR}/production-redis-negative.err"
 
-if helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" "${prod_set[@]}" --set secrets.create=true >/tmp/caracal-helm-secret-negative.yaml 2>/tmp/caracal-helm-secret-negative.err; then
+if helm template caracal "${ROOT}" -f "${ROOT}/values.production.yaml" "${prod_set[@]}" --set secrets.create=true >"${DIR}/secret-negative.yaml" 2>"${DIR}/secret-negative.err"; then
     echo "stable render with secrets.create=true must fail" >&2
     exit 1
 fi
-grep -q "secrets.create=true is forbidden when global.mode=stable" /tmp/caracal-helm-secret-negative.err
+grep -q "secrets.create=true is forbidden when global.mode=stable" "${DIR}/secret-negative.err"
 
-if helm template caracal "${ROOT}" -f "${ROOT}/values.rc.yaml" --set secrets.create=true >/tmp/caracal-helm-rc-secret-negative.yaml 2>/tmp/caracal-helm-rc-secret-negative.err; then
+if helm template caracal "${ROOT}" -f "${ROOT}/values.rc.yaml" --set secrets.create=true >"${DIR}/rc-secret-negative.yaml" 2>"${DIR}/rc-secret-negative.err"; then
     echo "rc render with plaintext secrets must require evaluation mode" >&2
     exit 1
 fi
-grep -q "global.evaluation=true" /tmp/caracal-helm-rc-secret-negative.err
+grep -q "global.evaluation=true" "${DIR}/rc-secret-negative.err"
 
-if grep -A8 -E 'port: 53' /tmp/caracal-helm-production.yaml; then
+if grep -A8 -E 'port: 53' "${DIR}/production.yaml"; then
     echo "production profile must not render open DNS egress" >&2
     exit 1
 fi
@@ -57,7 +60,7 @@ if awk '
     in_policy && /^---$/ { in_policy = 0 }
     in_policy && /port: 8081/ { found = 1 }
     END { exit found ? 0 : 1 }
-' /tmp/caracal-helm-production.yaml; then
+' "${DIR}/production.yaml"; then
     echo "production profile must not render broad Gateway ingress" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes #299. `infra/helm/caracal/scripts/validate.sh` rendered every manifest to fixed `/tmp/caracal-helm-*.yaml` (and `.err`) paths — 12 in total. Two problems:

- **Concurrent runs collide**: parallel invocations (e.g. CI matrix, two local shells) overwrite each other's files mid-run, producing flaky/wrong assertions.
- **Rendered secrets persist**: stable/production profiles render manifests that carry secret material, and these were left in `/tmp` after the script exited.

Per the maintainer's guidance, all artifacts now render into a single `mktemp -d` directory that is removed via `trap ... EXIT`.

## Changes

- `DIR="$(mktemp -d)"` + `trap 'rm -rf "${DIR}"' EXIT` immediately after the `helm` availability check.
- All 12 `/tmp/caracal-helm-*` paths rewritten to `"${DIR}/<name>"` (quoted, so a `TMPDIR` containing spaces is safe).

## Verification

All checks run against the real script:

- **Passes**: ran end-to-end with Helm 3.16.4 → `helm chart validation passed`, exit 0. The path refactor preserves every render, `grep`, and `awk` assertion.
- **Cleanup on success**: pointed `TMPDIR` at an observation dir; after a successful run it was empty (temp dir removed).
- **Cleanup on mid-run failure**: drove the real script with a `helm` stub that renders secret-bearing YAML and then fails on a later `template` call. The script exits non-zero, the temp dir is gone, and grepping the whole `TMPDIR` tree for the rendered secret string finds nothing — this is the exact "secrets persist" scenario from the issue, and the `EXIT` trap clears it.
- **Uniqueness**: successive runs produced distinct dirs, so concurrent runs no longer collide.

`bash -n` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
