### PR TITLE
fix(infra): cap CPU/memory on runtime-compose app services (#298)

### DIFF
--- a/infra/docker/dev.env
+++ b/infra/docker/dev.env
@@ -83,6 +83,12 @@ CARACAL_APP_MEM_LIMIT=512M
 # Per-app-container memory reservation.
 CARACAL_APP_MEM_RESERVE=128M
 
+# Gateway container CPU limit.
+CARACAL_GATEWAY_CPU_LIMIT=2.0
+
+# Gateway container memory limit.
+CARACAL_GATEWAY_MEM_LIMIT=1G
+
 # Postgres CPU limit.
 CARACAL_DB_CPU_LIMIT=2.0
 

--- a/infra/docker/runtime-compose.yml
+++ b/infra/docker/runtime-compose.yml
@@ -29,6 +29,17 @@ x-appService: &appService
   networks:
     - caracalData
 
+x-appResources: &appResources
+  deploy:
+    resources:
+      limits:
+        cpus: "${CARACAL_APP_CPU_LIMIT:-1.0}"
+        memory: "${CARACAL_APP_MEM_LIMIT:-1G}"
+        pids: 256
+      reservations:
+        cpus: "${CARACAL_APP_CPU_RESERVE:-0.1}"
+        memory: "${CARACAL_APP_MEM_RESERVE:-128M}"
+
 networks:
   caracalData:
     driver: bridge
@@ -192,7 +203,7 @@ services:
     entrypoint: ["/bin/sh", "/usr/local/bin/caracal-migrate"]
 
   sts:
-    <<: *appService
+    <<: [*appService, *appResources]
     image: ${CARACAL_REGISTRY:-ghcr.io/garudex-labs/}caracal-go:v${CARACAL_VERSION}
     command: ["/usr/local/bin/sts"]
     depends_on:
@@ -244,7 +255,7 @@ services:
       start_period: 15s
 
   api:
-    <<: *appService
+    <<: [*appService, *appResources]
     image: ${CARACAL_REGISTRY:-ghcr.io/garudex-labs/}caracal-node:v${CARACAL_VERSION}
     command: ["/app/api/dist/main.js"]
     depends_on:
@@ -302,9 +313,18 @@ services:
       start_period: 20s
 
   gateway:
-    <<: *appService
+    <<: [*appService, *appResources]
     image: ${CARACAL_REGISTRY:-ghcr.io/garudex-labs/}caracal-go:v${CARACAL_VERSION}
     command: ["/usr/local/bin/gateway"]
+    deploy:
+      resources:
+        limits:
+          cpus: "${CARACAL_GATEWAY_CPU_LIMIT:-2.0}"
+          memory: "${CARACAL_GATEWAY_MEM_LIMIT:-1G}"
+          pids: 256
+        reservations:
+          cpus: "${CARACAL_APP_CPU_RESERVE:-0.1}"
+          memory: "${CARACAL_APP_MEM_RESERVE:-128M}"
     depends_on:
       replayVolumeInit:
         condition: service_completed_successfully
@@ -353,7 +373,7 @@ services:
       start_period: 15s
 
   audit:
-    <<: *appService
+    <<: [*appService, *appResources]
     image: ${CARACAL_REGISTRY:-ghcr.io/garudex-labs/}caracal-go:v${CARACAL_VERSION}
     command: ["/usr/local/bin/audit"]
     depends_on:
@@ -393,7 +413,7 @@ services:
       start_period: 15s
 
   coordinator:
-    <<: *appService
+    <<: [*appService, *appResources]
     image: ${CARACAL_REGISTRY:-ghcr.io/garudex-labs/}caracal-node:v${CARACAL_VERSION}
     command: ["/app/coordinator/dist/main.js"]
     depends_on:
@@ -434,7 +454,7 @@ services:
       start_period: 20s
 
   web:
-    <<: *appService
+    <<: [*appService, *appResources]
     image: ${CARACAL_REGISTRY:-ghcr.io/garudex-labs/}caracal-web:v${CARACAL_VERSION}
     command: ["/app/auth/dist/server.js"]
     depends_on:

--- a/infra/docker/runtime-compose.yml
+++ b/infra/docker/runtime-compose.yml
@@ -34,7 +34,7 @@ x-appResources: &appResources
     resources:
       limits:
         cpus: "${CARACAL_APP_CPU_LIMIT:-1.0}"
-        memory: "${CARACAL_APP_MEM_LIMIT:-1G}"
+        memory: "${CARACAL_APP_MEM_LIMIT:-512M}"
         pids: 256
       reservations:
         cpus: "${CARACAL_APP_CPU_RESERVE:-0.1}"

--- a/packages/engine/src/envSchema.ts
+++ b/packages/engine/src/envSchema.ts
@@ -76,10 +76,20 @@ export const ENV_SCHEMA = {
     secret: true,
     file: 'postgresPassword',
   },
-  POSTGRES_SHARED_BUFFERS: { kind: 'string', description: 'shared_buffers tuning. Target ~25% of DB memory.', default: '256MB', exposed: true },
+  POSTGRES_SHARED_BUFFERS: {
+    kind: 'string',
+    description: 'shared_buffers tuning. Target ~25% of DB memory.',
+    default: '256MB',
+    exposed: true,
+  },
   POSTGRES_EFFECTIVE_CACHE_SIZE: { kind: 'string', description: 'effective_cache_size planner hint.', default: '768MB', exposed: true },
   POSTGRES_WORK_MEM: { kind: 'string', description: 'work_mem per sort/hash op.', default: '8MB', exposed: true },
-  POSTGRES_MAINTENANCE_WORK_MEM: { kind: 'string', description: 'maintenance_work_mem for VACUUM/CREATE INDEX.', default: '64MB', exposed: true },
+  POSTGRES_MAINTENANCE_WORK_MEM: {
+    kind: 'string',
+    description: 'maintenance_work_mem for VACUUM/CREATE INDEX.',
+    default: '64MB',
+    exposed: true,
+  },
   POSTGRES_MAX_CONNECTIONS: { kind: 'int', description: 'max_connections ceiling.', default: '100', exposed: true },
   POSTGRES_LOG_MIN_DURATION_MS: { kind: 'int', description: 'Slow query log threshold in ms.', default: '500', exposed: true },
 
@@ -150,7 +160,8 @@ export const ENV_SCHEMA = {
   },
   UPSTREAM_HOST_ALLOWLIST: {
     kind: 'string',
-    description: 'Gateway: optional comma-separated allowlist pinning upstream egress to named hosts. Empty permits any operator-provisioned host. Private and on-prem upstreams are allowed by default; dangerous ranges (cloud metadata, loopback, CGNAT, multicast) are always blocked.',
+    description:
+      'Gateway: optional comma-separated allowlist pinning upstream egress to named hosts. Empty permits any operator-provisioned host. Private and on-prem upstreams are allowed by default; dangerous ranges (cloud metadata, loopback, CGNAT, multicast) are always blocked.',
     default: '',
     exposed: true,
   },
@@ -181,6 +192,8 @@ export const ENV_SCHEMA = {
   CARACAL_APP_CPU_RESERVE: { kind: 'string', description: 'Per-app-container CPU reservation.', default: '0.1', exposed: true },
   CARACAL_APP_MEM_LIMIT: { kind: 'string', description: 'Per-app-container memory limit.', default: '512M', exposed: true },
   CARACAL_APP_MEM_RESERVE: { kind: 'string', description: 'Per-app-container memory reservation.', default: '128M', exposed: true },
+  CARACAL_GATEWAY_CPU_LIMIT: { kind: 'string', description: 'Gateway container CPU limit.', default: '2.0', exposed: true },
+  CARACAL_GATEWAY_MEM_LIMIT: { kind: 'string', description: 'Gateway container memory limit.', default: '1G', exposed: true },
   CARACAL_DB_CPU_LIMIT: { kind: 'string', description: 'Postgres CPU limit.', default: '2.0', exposed: true },
   CARACAL_DB_MEM_LIMIT: { kind: 'string', description: 'Postgres memory limit.', default: '1G', exposed: true },
   CARACAL_DB_MEM_RESERVE: { kind: 'string', description: 'Postgres memory reservation.', default: '256M', exposed: true },
@@ -195,7 +208,13 @@ export const ENV_SCHEMA = {
     default: '',
     exposed: true,
   },
-  LOG_LEVEL: { kind: 'enum', values: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'], description: 'Log verbosity for all services.', default: 'info', exposed: true },
+  LOG_LEVEL: {
+    kind: 'enum',
+    values: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
+    description: 'Log verbosity for all services.',
+    default: 'info',
+    exposed: true,
+  },
   OPERATOR_UPSTREAM_ALLOWLIST: {
     kind: 'string',
     description: 'Comma-separated host allowlist the Operator LLM normalizer may forward to. Blank allows any (dev).',


### PR DESCRIPTION
## Summary

Fixes #298. The `x-appService` anchor in `runtime-compose.yml` defined no `deploy.resources` limits, so every runtime app container (`sts`, `api`, `gateway`, `audit`, `coordinator`, `web`) ran with no CPU or memory cap. A single runaway container could exhaust the host and cascade into a full outage.

The dev stack (`docker-compose.yml`) already solves this with an `x-appResources` anchor and `CARACAL_APP_*` env vars (defaults in `dev.env`, rendered from `envSchema.ts`). This brings the runtime stack to parity.

## Changes

- Add a shared `x-appResources` anchor with environment-configurable limits + reservations, merged into all six app services via `<<: [*appService, *appResources]`:
  - `cpus: ${CARACAL_APP_CPU_LIMIT:-1.0}`, `memory: ${CARACAL_APP_MEM_LIMIT:-512M}`, `pids: 256`
  - reservations: `${CARACAL_APP_CPU_RESERVE:-0.1}` / `${CARACAL_APP_MEM_RESERVE:-128M}`
- Per-service override for **`gateway`** — the heaviest service (proxies all upstream traffic; 2 CPU / 1Gi with the widest HPA range in the Helm chart): `cpus: ${CARACAL_GATEWAY_CPU_LIMIT:-2.0}`, `memory: ${CARACAL_GATEWAY_MEM_LIMIT:-1G}`.
- All fallbacks match `packages/engine/src/envSchema.ts`; `CARACAL_GATEWAY_CPU_LIMIT` and `CARACAL_GATEWAY_MEM_LIMIT` are registered there (default `2.0` / `1G`) so they gain validation, docs exposure, and compose-drift coverage, and `dev.env` is regenerated.

Postgres/Redis are out of scope for this anchor and unchanged.

## Verification

- `docker compose config` valid; resolved per service: `sts`/`api`/`audit`/`coordinator`/`web` → cpu `1`, mem `512M`, `256` pids, `128M` reservation; `gateway` → cpu `2`, mem `1G`. Postgres/Redis untouched.
- Environment-configurable: overriding `CARACAL_APP_*` / `CARACAL_GATEWAY_*` changes the resolved limits (e.g. `CARACAL_APP_CPU_LIMIT=1.5 CARACAL_APP_MEM_LIMIT=2G` → app services `1.5`/`2G`; `CARACAL_GATEWAY_CPU_LIMIT=4` → gateway `4`).
- Live-container proof: brought up a container with the same `deploy.resources` block and confirmed via `docker inspect` that `docker compose` v2 (non-Swarm) applies real cgroup caps — `NanoCpus`, `Memory`, `MemoryReservation`, `PidsLimit` all set; env overrides flow through to the live caps.
- Schema/render/drift tests pass, including `compose-drift.test.ts`; `render-dev-env --check` reports no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CPU/memory resource limits and reservations across core services for more consistent runtime behavior.
  * Added gateway-specific CPU/memory limit overrides to improve deployment tuning.
  * Introduced default Gateway resource environment variables (CPU and memory) so local and configured environments behave predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->