### PR TITLE
fix(infra): remove temp pgpass file on migrate exit (#297)

### DIFF
--- a/infra/postgres/scripts/migrate.sh
+++ b/infra/postgres/scripts/migrate.sh
@@ -13,6 +13,7 @@ if [ -n "${PGPASSWORD_FILE:-}" ] && [ -r "${PGPASSWORD_FILE}" ]; then
     : "${PGUSER:?PGUSER required when PGPASSWORD_FILE is set}"
     : "${PGDATABASE:?PGDATABASE required when PGPASSWORD_FILE is set}"
     pgpass="$(mktemp "${TMPDIR:-/tmp}/caracal.pgpass.XXXXXX")"
+    trap 'rm -f "${pgpass:-}"' EXIT
     chmod 0600 "${pgpass}"
     printf '%s:%s:%s:%s:%s\n' "${PGHOST}" "${PGPORT}" "${PGDATABASE}" "${PGUSER}" "$(cat "${PGPASSWORD_FILE}")" > "${pgpass}"
     export PGPASSFILE="${pgpass}"


### PR DESCRIPTION
## Summary

Fixes #297. `infra/postgres/scripts/migrate.sh` creates a temporary pgpass file with `mktemp`, writes the database password into it, and exports it as `PGPASSFILE` — but never removed it. The plaintext credential was left on disk after every run.

## Change

Register an `EXIT` trap immediately after the file is created, before the password is written:

```sh
pgpass="$(mktemp "${TMPDIR:-/tmp}/caracal.pgpass.XXXXXX")"
trap 'rm -f "${pgpass:-}"' EXIT
```

Placing the trap right after `mktemp` means the file is cleaned on every exit path — normal completion, connect-retry exhaustion, and migration failure. The `${pgpass:-}` guard keeps it safe under `set -u`. The trap lives inside the `PGPASSWORD_FILE` branch, the only path that creates the file.

## Verification

Ran the real script (POSIX `sh`):

- `sh -n` syntax check passes.
- **Post-fix**: ran `migrate.sh` with `PGPASSWORD_FILE` set and an unreachable database so it creates the pgpass file then exits non-zero on connect-retry exhaustion. The temp directory was empty afterward and a grep for the password string found nothing — the trap removed the file on the failure exit.
- **Pre-fix (bug reproduced)**: the same run with the trap line stripped left `caracal.pgpass.XXXXXX` on disk containing `host:port:db:user:TOP-SECRET-DB-PASSWORD`, confirming both that the file really holds the credential and that the trap is what clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration cleanup by automatically removing temporary credentials files when the process ends, including on errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->