### PR TITLE
test(engine): assert dispatcher handler parity with the catalog (#296)

### DIFF
--- a/packages/engine/src/dispatch.ts
+++ b/packages/engine/src/dispatch.ts
@@ -197,12 +197,19 @@ function requireZone(principal: Principal): string {
 
 type Handler = (input: { sub: string; flags: FlagMap; principal: Principal; ctx: DispatchContext }) => Promise<unknown>
 
-function bySubcommand(handlers: Record<string, Handler>): Handler {
-  return async (input) => {
+/** A subcommand router that also reports which subcommands it implements, so handler coverage can
+ * be asserted against the catalog instead of only discovered when a dispatch fails. */
+interface SubcommandHandler extends Handler {
+  readonly handledSubcommands: readonly string[]
+}
+
+function bySubcommand(handlers: Record<string, Handler>): SubcommandHandler {
+  const route: Handler = async (input) => {
     const h = handlers[input.sub]
     if (!h) unsupported(`subcommand "${input.sub}" not implemented`)
     return h(input)
   }
+  return Object.assign(route, { handledSubcommands: Object.freeze(Object.keys(handlers)) })
 }
 
 const zoneHandler = bySubcommand({
@@ -490,6 +497,34 @@ function commandHandler(command: string): Handler | undefined {
     default:
       return undefined
   }
+}
+
+/**
+ * Catalog commands the engine intentionally does not route to Control. They are served by the
+ * local runtime surface (operator diagnostics, the in-process control-plane lifecycle, manifest
+ * validation, shell completion) and carry no dispatcher arm by design.
+ */
+export const LOCAL_ONLY_COMMANDS: readonly string[] = Object.freeze(['doctor', 'manifest', 'control', 'completion'])
+
+/**
+ * Subcommands of engine-routed commands that run locally rather than through Control. `zone use`
+ * selects the active local zone for subsequent commands and never reaches the Control API.
+ */
+export const LOCAL_ONLY_SUBCOMMANDS: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  zone: Object.freeze(['use']),
+})
+
+/**
+ * What the dispatcher implements for a catalog command, so handler coverage can be verified:
+ *  - `'local-only'` when no dispatcher arm exists (the command runs on the local runtime surface),
+ *  - `'all'` when a single handler accepts every declared subcommand,
+ *  - the explicit list of implemented subcommands for a subcommand router.
+ */
+export function engineHandlerCoverage(command: string): 'local-only' | 'all' | readonly string[] {
+  const handler = commandHandler(command)
+  if (!handler) return 'local-only'
+  const subs = (handler as Partial<SubcommandHandler>).handledSubcommands
+  return subs ?? 'all'
 }
 
 /**

--- a/tests/typescript/unit/engine/dispatchParity.test.ts
+++ b/tests/typescript/unit/engine/dispatchParity.test.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Verifies the dispatcher implements a handler for every engine-routed catalog subcommand, so a declared-but-unhandled subcommand fails the build instead of failing at dispatch time.
+
+import { describe, it, expect } from 'vitest'
+import { MANAGEMENT_COMMANDS } from '../../../../packages/engine/src/commands.js'
+import { LOCAL_ONLY_COMMANDS, LOCAL_ONLY_SUBCOMMANDS, engineHandlerCoverage } from '../../../../packages/engine/src/dispatch.js'
+
+describe('dispatch handler parity', () => {
+  it('routes every declared subcommand of every engine-routed command', () => {
+    for (const desc of MANAGEMENT_COMMANDS) {
+      const coverage = engineHandlerCoverage(desc.name)
+      if (coverage === 'local-only' || coverage === 'all') continue
+      const exempt = LOCAL_ONLY_SUBCOMMANDS[desc.name] ?? []
+      for (const sub of desc.subcommands ?? []) {
+        if (exempt.includes(sub)) continue
+        expect(coverage, `${desc.name} "${sub}" is declared but has no dispatcher arm`).toContain(sub)
+      }
+    }
+  })
+
+  it('treats every unrouted command as an explicit local-only exception', () => {
+    for (const desc of MANAGEMENT_COMMANDS) {
+      if (engineHandlerCoverage(desc.name) !== 'local-only') continue
+      expect(LOCAL_ONLY_COMMANDS, `${desc.name} has no dispatcher arm and is not allowlisted as local-only`).toContain(desc.name)
+    }
+  })
+
+  it('keeps the local-only command allowlist free of stale entries', () => {
+    for (const name of LOCAL_ONLY_COMMANDS) {
+      const desc = MANAGEMENT_COMMANDS.find((c) => c.name === name)
+      expect(desc, `local-only command "${name}" is no longer in the catalog`).toBeDefined()
+      expect(engineHandlerCoverage(name), `local-only command "${name}" now has a handler; remove it from the allowlist`).toBe('local-only')
+    }
+  })
+
+  it('keeps the local-only subcommand allowlist free of stale entries', () => {
+    for (const [command, subs] of Object.entries(LOCAL_ONLY_SUBCOMMANDS)) {
+      const desc = MANAGEMENT_COMMANDS.find((c) => c.name === command)
+      expect(desc, `local-only command "${command}" is no longer in the catalog`).toBeDefined()
+      const coverage = engineHandlerCoverage(command)
+      for (const sub of subs) {
+        expect(desc?.subcommands ?? [], `${command} "${sub}" is no longer a declared subcommand`).toContain(sub)
+        if (Array.isArray(coverage)) {
+          expect(coverage, `${command} "${sub}" now has a dispatcher arm; remove it from the allowlist`).not.toContain(sub)
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #296. A subcommand declared in the catalog (`MANAGEMENT_COMMANDS`) but missing a handler arm in the dispatcher compiled cleanly and only failed at runtime with `subcommand "x" not implemented`. There was no build-time guard against that drift.

Per the review on the issue, this does **not** force every declared subcommand to have a handler. Instead it distinguishes engine-routed commands from intentionally local-only ones and asserts handler coverage in a parity test, with explicit allowlists for the known exceptions.

## Changes

`packages/engine/src/dispatch.ts`:
- `bySubcommand` now reports the subcommands it implements (`handledSubcommands`), so coverage is introspectable instead of only discoverable on a failed dispatch.
- `engineHandlerCoverage(command)` returns `'local-only'` (no dispatcher arm — served by the local runtime surface), `'all'` (a single handler accepts every subcommand), or the explicit list of implemented subcommands.
- Explicit, exported allowlists encode intent: `LOCAL_ONLY_COMMANDS` (`doctor`, `manifest`, `control`, `completion`) and `LOCAL_ONLY_SUBCOMMANDS` (`zone use` — selects the active local zone, never reaches Control).

`tests/typescript/unit/engine/dispatchParity.test.ts` (new) asserts, against the catalog:
1. every engine-routed command implements a handler for each declared subcommand (except allowlisted local-only ones),
2. every unrouted command is an explicit local-only exception (catches a new engine command wired without a handler),
3. + 4. neither allowlist holds stale entries (a removed command, or a subcommand that later gains a handler, forces an allowlist update).

The runtime `unsupported` guard in `dispatch()` is kept as the final defense; the parity test moves detection to CI.

This mirrors the existing init-time descriptor↔executor parity check already enforced for the runtime CLI in `apps/runtime/src/registry.ts`.

## Verification

- Full engine suite: **108/108 pass** (including the 4 new parity tests).
- **Mutation-tested** the parity test against three regressions, each caught with a precise message:
  - declaring `app archive` with no handler → *"app \"archive\" is declared but has no dispatcher arm"*
  - dropping `doctor` from the allowlist → *"doctor has no dispatcher arm and is not allowlisted as local-only"*
  - removing `zone use` from the subcommand allowlist → *"zone \"use\" is declared but has no dispatcher arm"*
- No new type errors (engine `tsc` error count identical with/without the change — all pre-existing, from unbuilt workspace deps).
- Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer command-routing coverage for engine-managed commands, including explicit handling for commands that run locally and those covered by the main dispatcher.
  - Improved tracking of supported subcommands so command availability is more consistent.

- **Bug Fixes**
  - Strengthened validation to prevent unsupported or outdated command routing entries from lingering over time.
  - Preserved existing behavior for unknown subcommands, which still return an unsupported response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->