### PR TITLE
fix(api): degrade gracefully on unparseable STS responses (#294)

### DIFF
--- a/apps/api/src/routes/policy-sets.ts
+++ b/apps/api/src/routes/policy-sets.ts
@@ -5,13 +5,7 @@
 
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify'
 import { z } from 'zod'
-import {
-  GATEWAY_REQUEST_HEADER,
-  GATEWAY_SIGNATURE_HEADER,
-  GATEWAY_TIMESTAMP_HEADER,
-  sha256Hex,
-  signGatewayExchange,
-} from '@caracalai/core'
+import { GATEWAY_REQUEST_HEADER, GATEWAY_SIGNATURE_HEADER, GATEWAY_TIMESTAMP_HEADER, sha256Hex, signGatewayExchange } from '@caracalai/core'
 import { v7 as uuidv7 } from 'uuid'
 import { STREAM_POLICY_INVALIDATE } from '../redis.js'
 import { enqueueOutbox } from '../outbox.js'
@@ -30,7 +24,10 @@ const PolicySetBody = z.object({
 })
 
 const PolicySetVersionBody = z.object({
-  manifest: z.array(z.object({ policy_version_id: z.string().min(1) })).min(1).max(MANIFEST_MAX_ENTRIES),
+  manifest: z
+    .array(z.object({ policy_version_id: z.string().min(1) }))
+    .min(1)
+    .max(MANIFEST_MAX_ENTRIES),
   schema_version: z.string().default(OPA_INPUT_SCHEMA_VERSION),
 })
 
@@ -47,7 +44,11 @@ const SimulateBody = z.object({
   input: z.record(z.string(), z.unknown()).optional(),
 })
 
-const VersionParams = z.object({ zoneId: z.string().regex(/^[A-Za-z0-9_.\-:]{1,128}$/), id: z.string().regex(/^[A-Za-z0-9_.\-:]{1,128}$/), versionId: z.string().regex(/^[A-Za-z0-9_.\-:]{1,128}$/) })
+const VersionParams = z.object({
+  zoneId: z.string().regex(/^[A-Za-z0-9_.\-:]{1,128}$/),
+  id: z.string().regex(/^[A-Za-z0-9_.\-:]{1,128}$/),
+  versionId: z.string().regex(/^[A-Za-z0-9_.\-:]{1,128}$/),
+})
 
 export const policySetsRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/zones/:zoneId/policy-sets', async (req, reply) => {
@@ -121,10 +122,10 @@ export const policySetsRoutes: FastifyPluginAsync = async (fastify) => {
     const schemaErr = validatePolicySchemaVersion(body.schema_version)
     if (schemaErr) return reply.code(422).send({ error: 'invalid_schema_version', detail: schemaErr })
 
-    const { rows: psRows } = await fastify.db.query(
-      `SELECT id FROM policy_sets WHERE id = $1 AND zone_id = $2 AND archived_at IS NULL`,
-      [params.id, params.zoneId],
-    )
+    const { rows: psRows } = await fastify.db.query(`SELECT id FROM policy_sets WHERE id = $1 AND zone_id = $2 AND archived_at IS NULL`, [
+      params.id,
+      params.zoneId,
+    ])
     if (!psRows[0]) return reply.code(404).send({ error: 'policy_set_not_found' })
 
     const contractErr = await policySetContractError(fastify.db, params.zoneId, body.manifest, body.schema_version)
@@ -209,10 +210,9 @@ export const policySetsRoutes: FastifyPluginAsync = async (fastify) => {
       // delete of one of them blocks until activation commits. This closes the
       // TOCTOU between policySetContractError and the UPDATE below.
       if (referencedIds.length > 0) {
-        const { rowCount: lockedCount } = await client.query(
-          `SELECT id FROM policy_versions WHERE id = ANY($1::text[]) FOR SHARE`,
-          [Array.from(new Set(referencedIds))],
-        )
+        const { rowCount: lockedCount } = await client.query(`SELECT id FROM policy_versions WHERE id = ANY($1::text[]) FOR SHARE`, [
+          Array.from(new Set(referencedIds)),
+        ])
         if ((lockedCount ?? 0) !== new Set(referencedIds).size) {
           throw new TxAbort(reply.code(409).send({ error: 'referenced_policy_version_missing' }))
         }
@@ -308,12 +308,12 @@ export const policySetsRoutes: FastifyPluginAsync = async (fastify) => {
     const inputWarnings = validateSimulationInput(body.input, params.zoneId)
     const execution = body.input
       ? await executePolicySimulation(fastify, {
-        policy_set_id: params.id,
-        version_id: rows[0].id,
-        manifest_sha256: rows[0].manifest_sha256,
-        policies: contract.policies.map((policy) => ({ id: policy.id, content: policy.content })),
-        input: body.input,
-      })
+          policy_set_id: params.id,
+          version_id: rows[0].id,
+          manifest_sha256: rows[0].manifest_sha256,
+          policies: contract.policies.map((policy) => ({ id: policy.id, content: policy.content })),
+          input: body.input,
+        })
       : null
     return {
       dry_run: true,
@@ -404,14 +404,12 @@ interface STSPolicyStatus {
 
 function collectManifestIds(manifest: string | PolicyManifest): string[] {
   const list = Array.isArray(manifest) ? manifest : parseManifest(manifest)
-  return list
-    .map((entry) => entry.policy_version_id)
-    .filter((id): id is string => typeof id === 'string' && id !== '')
+  return list.map((entry) => entry.policy_version_id).filter((id): id is string => typeof id === 'string' && id !== '')
 }
 
 function parseManifest(raw: string): PolicyManifest {
   const parsed = JSON.parse(raw)
-  return Array.isArray(parsed) ? parsed as PolicyManifest : []
+  return Array.isArray(parsed) ? (parsed as PolicyManifest) : []
 }
 
 async function policySetContractError(
@@ -454,7 +452,10 @@ async function policySetContract(
       return { policies: [], error: `policy version ${row.id} belongs to a different zone` }
     }
     if (row.schema_version !== schemaVersion) {
-      return { policies: [], error: `policy version ${row.id} schema ${row.schema_version} does not match policy set schema ${schemaVersion}` }
+      return {
+        policies: [],
+        error: `policy version ${row.id} schema ${row.schema_version} does not match policy set schema ${schemaVersion}`,
+      }
     }
     const versionErr = validatePolicySchemaVersion(row.schema_version)
     if (versionErr) return { policies: [], error: `policy version ${row.id} failed schema validation: ${versionErr}` }
@@ -491,7 +492,14 @@ async function executePolicySimulation(
         'content-type': 'application/json',
         [GATEWAY_TIMESTAMP_HEADER]: String(timestamp),
         [GATEWAY_REQUEST_HEADER]: requestId,
-        [GATEWAY_SIGNATURE_HEADER]: signGatewayExchange(fastify.cfg.gatewayStsHmacKey, timestamp, requestId, 'POST', '/internal/policy/simulate', body),
+        [GATEWAY_SIGNATURE_HEADER]: signGatewayExchange(
+          fastify.cfg.gatewayStsHmacKey,
+          timestamp,
+          requestId,
+          'POST',
+          '/internal/policy/simulate',
+          body,
+        ),
       },
       body,
     })
@@ -505,7 +513,19 @@ async function executePolicySimulation(
       result: null,
     }
   }
-  const payload = await response.json() as Record<string, unknown>
+  let payload: Record<string, unknown>
+  try {
+    payload = (await response.json()) as Record<string, unknown>
+  } catch (err) {
+    return {
+      warnings: [`sts_simulation_invalid_response:${err instanceof Error ? err.message : String(err)}`],
+      explanation: {
+        evaluation: 'failed',
+        reason: 'STS simulation returned an unparseable response',
+      },
+      result: null,
+    }
+  }
   if (!response.ok) {
     return {
       warnings: [`sts_simulation_failed:${String(payload.error ?? response.status)}`],
@@ -525,22 +545,17 @@ async function executePolicySimulation(
       manifest_sha256: payload.manifest_sha256,
       reason: 'OPA evaluated the supplied input through the STS runtime engine without mutating active policy bindings',
     },
-    result: payload.result && typeof payload.result === 'object' ? payload.result as Record<string, unknown> : null,
+    result: payload.result && typeof payload.result === 'object' ? (payload.result as Record<string, unknown>) : null,
   }
 }
 
-async function policyActivationOutboxStatus(
-  db: Queryable,
-  request: PolicyActivationOutboxRequest,
-): Promise<PolicyActivationOutboxStatus> {
+async function policyActivationOutboxStatus(db: Queryable, request: PolicyActivationOutboxRequest): Promise<PolicyActivationOutboxStatus> {
   const expected = {
     zone_id: request.zoneId,
     policy_set_id: request.policySetId,
     policy_set_version_id: request.versionId,
   }
-  const params: string[] = request.outboxId
-    ? [request.outboxId]
-    : [STREAM_POLICY_INVALIDATE, JSON.stringify(expected)]
+  const params: string[] = request.outboxId ? [request.outboxId] : [STREAM_POLICY_INVALIDATE, JSON.stringify(expected)]
   const sql = request.outboxId
     ? `SELECT id, stream_name, payload_json, attempts, last_error, dispatched_at, available_at
        FROM event_outbox WHERE id = $1`
@@ -562,18 +577,20 @@ async function policyActivationOutboxStatus(
     return { id: request.outboxId ?? null, state: 'missing', attempts: 0, last_error: null, dispatched_at: null }
   }
   if (
-    row.stream_name !== STREAM_POLICY_INVALIDATE
-    || row.payload_json.zone_id !== request.zoneId
-    || row.payload_json.policy_set_id !== request.policySetId
-    || row.payload_json.policy_set_version_id !== request.versionId
+    row.stream_name !== STREAM_POLICY_INVALIDATE ||
+    row.payload_json.zone_id !== request.zoneId ||
+    row.payload_json.policy_set_id !== request.policySetId ||
+    row.payload_json.policy_set_version_id !== request.versionId
   ) {
-    return { id: row.id, state: 'mismatch', attempts: row.attempts, last_error: row.last_error, dispatched_at: formatDate(row.dispatched_at) }
+    return {
+      id: row.id,
+      state: 'mismatch',
+      attempts: row.attempts,
+      last_error: row.last_error,
+      dispatched_at: formatDate(row.dispatched_at),
+    }
   }
-  const state = row.dispatched_at
-    ? 'dispatched'
-    : String(row.available_at) === 'infinity'
-      ? 'dead'
-      : 'pending'
+  const state = row.dispatched_at ? 'dispatched' : String(row.available_at) === 'infinity' ? 'dead' : 'pending'
   return { id: row.id, state, attempts: row.attempts, last_error: row.last_error, dispatched_at: formatDate(row.dispatched_at) }
 }
 
@@ -595,7 +612,12 @@ async function fetchSTSPolicyStatus(fastify: FastifyInstance, zoneId: string): P
   } catch (err) {
     return { state: 'unreachable', detail: err instanceof Error ? err.message : String(err) }
   }
-  const payload = await response.json() as Record<string, unknown>
+  let payload: Record<string, unknown>
+  try {
+    payload = (await response.json()) as Record<string, unknown>
+  } catch (err) {
+    return { state: 'failed', detail: `invalid STS response: ${err instanceof Error ? err.message : String(err)}` }
+  }
   if (!response.ok) {
     return { state: 'failed', detail: String(payload.detail ?? payload.error ?? response.status) }
   }

--- a/tests/typescript/unit/api/routes/policy-sets-sts-degradation.test.ts
+++ b/tests/typescript/unit/api/routes/policy-sets-sts-degradation.test.ts
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Policy-set route tests for graceful degradation when STS returns an unparseable (non-JSON) response body.
+
+import { describe, it, expect, vi } from 'vitest'
+import { policySetsRoutes } from '../../../../../apps/api/src/routes/policy-sets.js'
+import { buildRouteApp } from '../../../../shared/test-utils/typescript/fastify.js'
+
+describe('policy-sets STS response degradation', () => {
+  it('degrades gracefully when STS returns an unparseable simulation body', async () => {
+    const { app, db } = buildRouteApp(policySetsRoutes)
+    app.decorate('cfg', {
+      stsUrl: 'http://sts.local',
+      gatewayStsHmacKey: Buffer.alloc(32, 1),
+    } as never)
+    db.query
+      .mockResolvedValueOnce({
+        rows: [{ id: 'psv-1', manifest_json: [{ policy_version_id: 'pv-1' }], manifest_sha256: 'sha-1', schema_version: '2026-05-20' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'pv-1',
+            content: '# caracal:data-document\npackage caracal.authz\ngrants := {}',
+            zone_id: 'z1',
+            schema_version: '2026-05-20',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('<html>502 Bad Gateway</html>', { status: 200, headers: { 'content-type': 'application/json' } }))
+
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/policy-sets/ps-1/simulate',
+      payload: {
+        version_id: 'psv-1',
+        input: {
+          schema_version: '2026-05-20',
+          principal: { zone_id: 'z1' },
+          resource: { identifier: 'resource://calendar' },
+          action: { id: 'token_exchange' },
+          context: {},
+        },
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.body)).toMatchObject({
+      explanation: { evaluation: 'failed', reason: 'STS simulation returned an unparseable response' },
+      result: null,
+    })
+    expect(JSON.parse(res.body).warnings).toEqual(expect.arrayContaining([expect.stringMatching(/^sts_simulation_invalid_response:/)]))
+    fetchMock.mockRestore()
+  })
+
+  it('marks STS failed when the status response body is unparseable', async () => {
+    const { app, db } = buildRouteApp(policySetsRoutes)
+    app.decorate('cfg', {
+      stsUrl: 'http://sts.local',
+      gatewayStsHmacKey: Buffer.alloc(32, 1),
+    } as never)
+    db.query
+      .mockResolvedValueOnce({ rows: [{ active_version_id: 'psv-1', shadow_version_id: null, manifest_sha256: 'sha-1' }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'outbox-1',
+            stream_name: 'caracal.policy.invalidate',
+            payload_json: { zone_id: 'z1', policy_set_id: 'ps-1', policy_set_version_id: 'psv-1' },
+            attempts: 1,
+            last_error: null,
+            dispatched_at: new Date('2026-01-01T00:00:00Z'),
+            available_at: new Date('2026-01-01T00:00:00Z'),
+          },
+        ],
+      })
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('not json', { status: 200, headers: { 'content-type': 'application/json' } }))
+
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/zones/z1/policy-sets/ps-1/activation-status?version_id=psv-1&outbox_id=outbox-1',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.sts.state).toBe('failed')
+    expect(body.sts.detail).toMatch(/invalid STS response/)
+    expect(body.propagation_status).toBe('failed')
+    fetchMock.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #294. In `apps/api/src/routes/policy-sets.ts`, both STS calls parsed the response body with `await response.json()` **outside** any try/catch:

- `executePolicySimulation` (line 508)
- `fetchSTSPolicyStatus` (line 598)

Each already degrades gracefully when STS is unreachable or returns a non-2xx JSON error, but a **non-JSON body** (a proxy/load-balancer error page, a truncated payload) made `.json()` throw straight past those paths and surface as a generic 500 — the opposite of the intended graceful degradation.

## Changes

Per the review, wrap each parse in try/catch and return the route's **existing** degraded shape on parse failure:

- Simulation: a failed explanation `{ evaluation: 'failed', reason: 'STS simulation returned an unparseable response' }` with an `sts_simulation_invalid_response:<msg>` warning — same structure as the existing `sts_simulation_unreachable` / `sts_simulation_failed` paths.
- Status: `{ state: 'failed', detail: 'invalid STS response: <msg>' }` — reuses the existing `failed` state, so `propagation_status` resolves to `failed` exactly as it does for any other STS failure.

No new error types or branches beyond what the route already models.

## Verification

Added two unit tests (mocking `fetch` to return a non-JSON body), and verified the full route suite: **24/24 pass**.

Mutation-checked that the tests actually catch the bug — reverting the try/catch makes both new tests fail with `expected 500 to be 200`, i.e. the exact generic-500 symptom from the issue; with the fix they return the degraded `200`.

- Simulation malformed body → `200`, `explanation.evaluation = 'failed'`, `reason = 'STS simulation returned an unparseable response'`, `sts_simulation_invalid_response` warning.
- Status malformed body → `200`, `sts.state = 'failed'`, `detail` matches `invalid STS response`, `propagation_status = 'failed'`.

No new type errors introduced (the only `tsc` finding in the file is the pre-existing workspace module-resolution import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed responses from the status/simulation service, so policy set activation and simulation now fail gracefully with clear error details instead of surfacing parsing errors.
  * Activation status checks now report a failed state when the upstream response can’t be interpreted, helping users understand propagation issues more easily.

* **Tests**
  * Added coverage for malformed upstream responses to verify the new failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->