### PR TITLE
fix(web): announce DataTable sort state with aria-sort/aria-label (#284)

### DIFF
--- a/apps/web/src/components/ui/DataTable.tsx
+++ b/apps/web/src/components/ui/DataTable.tsx
@@ -32,6 +32,7 @@ export interface SortState {
 function SortGlyph({ active, direction }: { active: boolean; direction: SortDirection }) {
   return (
     <span
+      aria-hidden="true"
       className={cx(
         "inline-flex flex-col leading-none",
         active ? "text-foreground" : "text-muted-foreground/40",
@@ -102,9 +103,18 @@ export function DataTable<T>({
               <tr className="bg-muted text-left">
                 {columns.map((col) => {
                   const active = sort?.column === col.id;
+                  const ariaSort =
+                    col.sortable && onSortChange
+                      ? active
+                        ? sort?.direction === "desc"
+                          ? "descending"
+                          : "ascending"
+                        : "none"
+                      : undefined;
                   return (
                     <th
                       key={col.id}
+                      aria-sort={ariaSort}
                       style={col.width ? { width: col.width } : undefined}
                       className={cx(
                         "border-b border-border px-4 py-2.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground whitespace-nowrap",
@@ -115,6 +125,7 @@ export function DataTable<T>({
                       {col.sortable && onSortChange ? (
                         <button
                           onClick={() => onSortChange(col.id)}
+                          aria-label={`Sort by ${col.header}`}
                           className={cx(
                             "inline-flex items-center gap-1 outline-none transition-colors hover:text-foreground",
                             col.align === "right" && "flex-row-reverse",

--- a/tests/typescript/unit/web/dataTableSort.test.ts
+++ b/tests/typescript/unit/web/dataTableSort.test.ts
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Verifies the DataTable announces sort state to assistive tech via aria-sort, aria-label, and aria-hidden.
+
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { DataTable, type Column, type SortState } from '@/components/ui/DataTable'
+
+interface Row {
+  id: string
+  name: string
+}
+
+const columns: Column<Row>[] = [
+  { id: 'name', header: 'Name', sortable: true, cell: (r) => r.name },
+  { id: 'created', header: 'Created', sortable: true, cell: () => '-' },
+  { id: 'plain', header: 'Plain', cell: () => '-' },
+]
+
+const rows: Row[] = [{ id: '1', name: 'PiperNet' }]
+
+function render(sort?: SortState): string {
+  return renderToStaticMarkup(
+    createElement(DataTable<Row>, {
+      columns,
+      rows,
+      rowKey: (r) => r.id,
+      sort,
+      onSortChange: () => {},
+    }),
+  )
+}
+
+function count(html: string, needle: RegExp): number {
+  return html.match(needle)?.length ?? 0
+}
+
+describe('DataTable sort accessibility', () => {
+  it('marks the active ascending column aria-sort=ascending and other sortable columns none', () => {
+    const html = render({ column: 'name', direction: 'asc' })
+    expect(count(html, /aria-sort="ascending"/g)).toBe(1)
+    expect(count(html, /aria-sort="none"/g)).toBe(1)
+    expect(html).not.toContain('aria-sort="descending"')
+  })
+
+  it('marks the active descending column aria-sort=descending', () => {
+    const html = render({ column: 'name', direction: 'desc' })
+    expect(count(html, /aria-sort="descending"/g)).toBe(1)
+    expect(count(html, /aria-sort="none"/g)).toBe(1)
+    expect(html).not.toContain('aria-sort="ascending"')
+  })
+
+  it('marks every sortable column aria-sort=none when nothing is sorted', () => {
+    const html = render()
+    expect(count(html, /aria-sort="none"/g)).toBe(2)
+    expect(html).not.toContain('aria-sort="ascending"')
+    expect(html).not.toContain('aria-sort="descending"')
+  })
+
+  it('only sortable columns carry aria-sort', () => {
+    // Two sortable columns, one plain: exactly two aria-sort attributes render.
+    const html = render({ column: 'name', direction: 'asc' })
+    expect(count(html, /aria-sort=/g)).toBe(2)
+  })
+
+  it('gives each sort button a descriptive aria-label and no label on plain headers', () => {
+    const html = render()
+    expect(html).toContain('aria-label="Sort by Name"')
+    expect(html).toContain('aria-label="Sort by Created"')
+    expect(html).not.toContain('aria-label="Sort by Plain"')
+  })
+
+  it('hides the decorative sort glyph from assistive tech', () => {
+    const html = render({ column: 'name', direction: 'asc' })
+    expect(count(html, /aria-hidden="true"/g)).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #284. Sortable `DataTable` headers were plain buttons with no accessible sort semantics, so screen-reader users could not determine or track which column was sorted.

Implements the maintainer's refined approach:

- **`aria-sort` on the `<th>`** (the column header, per WAI-ARIA): `ascending`/`descending` for the active column, `none` for other sortable columns, and omitted entirely for non-sortable columns.
- **Descriptive `aria-label` on the sort button** (`Sort by {header}`) — the button conveys the action while the header's `aria-sort` owns the state, avoiding double-announcement.
- **`aria-hidden` on the decorative sort glyph** so it is not announced.

## Verification

Added `tests/typescript/unit/web/dataTableSort.test.ts`, which renders the real component with `renderToStaticMarkup` and asserts the emitted markup across sort states:

- active ascending → exactly one `aria-sort="ascending"`, others `none`, no `descending`
- active descending → `aria-sort="descending"`
- unsorted → every sortable column `aria-sort="none"`
- only sortable columns carry `aria-sort` (the plain column has none)
- each sort button has `aria-label="Sort by <header>"`; plain headers have none
- the decorative glyph renders `aria-hidden="true"`

**6/6 pass.** Mutation-checked: removing `aria-sort` from the header fails 4 of the 6 assertions, so the test genuinely guards the behavior. `tsc` is clean for the component and the web app builds.

### Note on unrelated CI

The shared `TypeScript … tests` job currently has pre-existing failures unrelated to this change — a date-dependent flake in `web/operatorView.test.ts` and an `entry.actions` bug in `web/errors.test.ts` — both of which fail on `main` independently of this PR (this PR touches only `DataTable.tsx` and the new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved table sorting controls for assistive technologies.
  * Added clearer labels for sortable column controls and hidden decorative sort icons from screen readers.
  * Exposed current sort state on table headers, including unsorted, ascending, and descending states.

* **Tests**
  * Added coverage to verify the table’s accessible sort behavior across sortable and non-sortable columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->