### PR TITLE
fix(web): keep application rename failures recoverable

### DIFF
--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.applications.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.applications.tsx
@@ -256,9 +256,10 @@ function ApplicationsPage({ zoneId, zoneName }: { zoneId: string; zoneName: stri
                 try {
                   await updateApp.mutateAsync({ id: app.id, input: { name } });
                   toast({ tone: "success", title: "Application renamed", description: name });
+                  return true;
                 } catch (err) {
                   toast({ tone: "error", title: "Rename failed", description: errorMessage(err) });
-                  throw err;
+                  return false;
                 }
               }}
               onRotate={() => setRotateTarget(app)}
@@ -370,7 +371,7 @@ function ApplicationDetail({
 }: {
   app: Application;
   busy: boolean;
-  onRename: (name: string) => Promise<void>;
+  onRename: (name: string) => Promise<boolean>;
   onRotate: () => void;
   onDelete: () => void;
 }) {
@@ -421,7 +422,7 @@ function IdentitySection({
 }: {
   app: Application;
   busy: boolean;
-  onRename: (name: string) => Promise<void>;
+  onRename: (name: string) => Promise<boolean>;
 }) {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(app.name);
@@ -430,6 +431,15 @@ function IdentitySection({
     setName(app.name);
     setEditing(false);
   }, [app.id, app.name]);
+
+  function commitRename() {
+    const nextName = name.trim();
+    if (!nextName || nextName === app.name) return;
+
+    void onRename(nextName).then((renamed) => {
+      if (renamed) setEditing(false);
+    });
+  }
 
   return (
     <DetailGroup title="Identity">
@@ -444,8 +454,8 @@ function IdentitySection({
                 className="flex-1"
                 autoFocus
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && name.trim() && name.trim() !== app.name) {
-                    void onRename(name.trim()).then(() => setEditing(false));
+                  if (e.key === "Enter") {
+                    commitRename();
                   } else if (e.key === "Escape") {
                     setName(app.name);
                     setEditing(false);
@@ -457,7 +467,7 @@ function IdentitySection({
                 loading={busy}
                 mutating
                 disabled={!name.trim() || name.trim() === app.name}
-                onClick={() => void onRename(name.trim()).then(() => setEditing(false))}
+                onClick={commitRename}
               >
                 Save
               </Button>

--- a/tests/typescript/unit/web/applicationRename.test.ts
+++ b/tests/typescript/unit/web/applicationRename.test.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Regression coverage for application rename failure handling.
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync('apps/web/src/routes/$accountId.$orgId.$zoneId.app.applications.tsx', 'utf8')
+
+describe('application rename failure handling', () => {
+  it('keeps recoverable rename failures out of the route error boundary', () => {
+    expect(source).toContain('return false;')
+    expect(source).not.toContain('throw err;')
+  })
+
+  it('keeps the rename editor open when the mutation reports failure', () => {
+    expect(source).toContain('Promise<boolean>')
+    expect(source).toContain('if (renamed) setEditing(false);')
+    expect(source).not.toContain('then(() => setEditing(false))')
+  })
+})


### PR DESCRIPTION
Closes #282.

## Summary
- make application rename submitters return a success flag instead of rethrowing recoverable failures
- keep the rename editor open when the mutation fails
- close the editor only after a successful rename
- add regression coverage for the rename failure control flow

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tests/typescript/unit/web/applicationRename.test.ts`
- `pnpm --dir apps/web typecheck`
- `pnpm run style`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application rename behavior so failed saves no longer close the editor. The rename field now stays open on error, and successful renames still save and exit normally.
  * Refined rename interactions so pressing Enter or clicking Save follows the same save-and-keep-open-until-success behavior.

* **Tests**
  * Added coverage for rename failure handling to ensure the editor remains open when a save does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->