### PR TITLE
fix(testing): handle Go test runs when race detection is unavailable

### DIFF
--- a/scripts/runGoTests.mjs
+++ b/scripts/runGoTests.mjs
@@ -57,6 +57,25 @@ function run(command, args) {
   if (status !== 0) process.exit(status)
 }
 
+function goEnv(name) {
+  const result = spawnSync('go', ['env', name], { cwd: root, encoding: 'utf8' })
+  if (result.status !== 0) {
+    process.stderr.write(`failed to read go env ${name}\n`)
+    process.exit(result.status ?? 1)
+  }
+  return result.stdout.trim()
+}
+
+function raceArgs() {
+  if (goEnv('CGO_ENABLED') !== '0') return ['-race']
+  if (process.env.CI) {
+    process.stderr.write('Go race tests require CGO_ENABLED=1; enable cgo for CI.\n')
+    process.exit(1)
+  }
+  process.stderr.write('warning: CGO_ENABLED=0; running Go tests without -race.\n')
+  return []
+}
+
 function collectTestFiles(dir) {
   const files = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -99,9 +118,10 @@ const mode = process.argv[2] ?? ''
 if (mode === '--vet') {
   run('go', ['vet', ...GO_PKGS])
 } else if (mode === '--coverage') {
+  const race = raceArgs()
   mkdirSync(join(root, 'coverage', 'go'), { recursive: true })
-  runWithStagedSourceTests(['test', '-race', '-covermode=atomic', '-coverprofile=coverage/go/coverage.out', ...GO_PKGS])
-  run('go', ['test', '-race', '-covermode=atomic', `-coverpkg=${COVERPKG}`, '-coverprofile=coverage/go/tests.out', ...TEST_DIRS])
+  runWithStagedSourceTests(['test', ...race, '-covermode=atomic', '-coverprofile=coverage/go/coverage.out', ...GO_PKGS])
+  run('go', ['test', ...race, '-covermode=atomic', `-coverpkg=${COVERPKG}`, '-coverprofile=coverage/go/tests.out', ...TEST_DIRS])
   const merged = readFileSync(join(root, 'coverage', 'go', 'tests.out'), 'utf8')
     .split('\n')
     .slice(1)
@@ -109,8 +129,9 @@ if (mode === '--vet') {
   appendFileSync(join(root, 'coverage', 'go', 'coverage.out'), merged)
   run('go', ['tool', 'cover', '-func=coverage/go/coverage.out'])
 } else if (mode === '') {
-  runWithStagedSourceTests(['test', '-race', ...GO_PKGS])
-  run('go', ['test', '-race', ...TEST_DIRS])
+  const race = raceArgs()
+  runWithStagedSourceTests(['test', ...race, ...GO_PKGS])
+  run('go', ['test', ...race, ...TEST_DIRS])
 } else {
   process.stderr.write('usage: node scripts/runGoTests.mjs [--coverage|--vet]\n')
   process.exit(2)


### PR DESCRIPTION
## Summary

- detect when Go race tests cannot run because CGO is disabled
- keep CI strict with a clear failure when race detection is unavailable
- allow local Go test runs to continue without `-race` when `CGO_ENABLED=0`

## Why

`scripts/runGoTests.mjs` always passed `-race`, but Go race detection requires CGO. On Windows or other environments with `CGO_ENABLED=0`, the official Go test command failed immediately before running tests. This makes local validation harder for contributors even though non-race Go tests can still run.

## Testing

- On `main`, with `CGO_ENABLED=0`, `node scripts\runGoTests.mjs` fails immediately with `go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`
- On this branch, with `CGO_ENABLED=0`, `node scripts\runGoTests.mjs` prints `warning: CGO_ENABLED=0; running Go tests without -race.` and proceeds into the Go test suite
- The Go suite then reaches package-level tests; some tests fail separately on Windows/temp-file permission behavior, confirming the race detector failure is no longer the blocker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Go tests now automatically enable race detection only when the environment supports it.
  * If race testing can’t run locally, the test script now warns instead of failing; in CI, it still fails fast.
  * Coverage runs and standard test runs now use the same conditional race-check behavior, keeping reporting unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->