### PR TITLE
fix(fastmcp): preserve auth error hints

### DIFF
--- a/packages/adapters/fastmcp/ts/src/middleware.ts
+++ b/packages/adapters/fastmcp/ts/src/middleware.ts
@@ -16,16 +16,19 @@ export interface FastMcpContext {
 }
 
 export class FastMcpAuthError extends CaracalError {
-  constructor(code: AuthErrorCode, description: string) {
+  readonly hint?: string
+
+  constructor(code: AuthErrorCode, description: string, hint?: string) {
     super(code, description)
     this.name = 'FastMcpAuthError'
+    this.hint = hint
   }
 }
 
 export async function verifyFastMcpToken(token: string, opts: FastMcpAuthOptions, route: AuthOverrides = {}): Promise<FastMcpContext> {
   const result =
     'authenticate' in opts && 'defaults' in opts ? await opts.authenticate(token, route) : await authenticate(token, { ...opts, ...route })
-  if (!result.ok) throw new FastMcpAuthError(result.error.code, result.error.description)
+  if (!result.ok) throw new FastMcpAuthError(result.error.code, result.error.description, result.error.hint)
   const claims = result.principal
   return { sub: claims.sub, zoneId: claims.zoneId, scope: claims.scope }
 }

--- a/tests/typescript/unit/adapters/fastmcp/middleware.test.ts
+++ b/tests/typescript/unit/adapters/fastmcp/middleware.test.ts
@@ -113,6 +113,7 @@ describe('verifyFastMcpToken', () => {
       name: 'FastMcpAuthError',
       code: 'chain_mismatch',
       message: 'Delegation chain missing application: app-parent',
+      hint: 'Check requireChainContains and the mandate delegation chain.',
     } satisfies Partial<FastMcpAuthError>)
   })
 


### PR DESCRIPTION
## Summary

- Preserve `AuthError.hint` on TypeScript `FastMcpAuthError`
- Pass verifier error hints through `verifyFastMcpToken`
- Add a unit assertion covering the propagated hint

## Why

`@caracalai/verify` already returns remediation hints for auth failures, but the TypeScript FastMCP adapter discarded them when throwing `FastMcpAuthError`.

Python FastMCP already preserves the same field on `CaracalAuthError`, and other framework adapters expose auth hints to callers. This keeps the TypeScript FastMCP connector consistent and gives provider developers the same debugging guidance.

## Testing

```powershell
packages\sdk\ts\node_modules\.bin\vitest.CMD run --root . tests\typescript\unit\adapters\fastmcp\middleware.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication failures now surface an additional hint when available, giving clearer guidance on why token verification failed.
  * The updated error details are also reflected in the related validation flow, improving troubleshooting for failed sign-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->