### PR TITLE
fix(sdk): include governed transport options in cache key

### DIFF
--- a/packages/sdk/go/client.go
+++ b/packages/sdk/go/client.go
@@ -1428,9 +1428,9 @@ type GovernedTransportOptions struct {
 // across them bounded to resourceID, and mints the mandate from that edge, so
 // each call is policy-checked, delegation-bounded, and fully audited without
 // a caller-supplied CaracalContext. Mandates are cached per resolved
-// identity, resource, and scope set and re-provisioned before expiry.
-// Requests are rewritten through the gateway. Requires a client-secret
-// configuration.
+// identity, resource, scope set, effective labels, and mandate TTL, then
+// re-provisioned before expiry. Requests are rewritten through the gateway.
+// Requires a client-secret configuration.
 func (c *Caracal) GovernedTransport(base *http.Client, resourceID string, opts GovernedTransportOptions) (*http.Client, error) {
 	if c.exchanger == nil {
 		return nil, fmt.Errorf("caracal: GovernedTransport requires a client-secret configuration")
@@ -1638,7 +1638,7 @@ func (c *Caracal) governedMandate(ctx context.Context, resourceID string, scopes
 	if len(sessionLabels) == 0 {
 		sessionLabels = []string{applicationID}
 	}
-	key := zoneID + "::" + applicationID + "::" + resourceID + "::" + strings.Join(scopes, " ") + "::" + strings.Join(sessionLabels, " ") + "::" + strconv.Itoa(mandateTTL)
+	key := governedMandateKey(zoneID, applicationID, resourceID, scopes, sessionLabels, mandateTTL)
 	c.governedMu.Lock()
 	if cached, ok := c.governedMandates[key]; ok && time.Until(cached.expiresAt) > governedRefreshMargin {
 		c.governedMu.Unlock()
@@ -1673,6 +1673,11 @@ func (c *Caracal) governedMandate(ctx context.Context, resourceID string, scopes
 	c.governedMu.Unlock()
 	close(call.done)
 	return token, err
+}
+
+func governedMandateKey(zoneID, applicationID, resourceID string, scopes, labels []string, mandateTTL int) string {
+	encodedLabels, _ := json.Marshal(labels)
+	return zoneID + "::" + applicationID + "::" + resourceID + "::" + strings.Join(scopes, " ") + "::" + string(encodedLabels) + "::" + strconv.Itoa(mandateTTL)
 }
 
 // governedCycle provisions one governed mandate under the application's own

--- a/packages/sdk/go/client.go
+++ b/packages/sdk/go/client.go
@@ -1627,14 +1627,18 @@ type governedCall struct {
 }
 
 // governedMandate returns a cached or freshly provisioned governed mandate
-// for the resource and scope set under the current resolved identity.
+// for the resource, scope set, labels, and TTL under the current resolved identity.
 // Concurrent requests for the same key share one provisioning cycle.
 func (c *Caracal) governedMandate(ctx context.Context, resourceID string, scopes, labels []string, mandateTTL int) (string, error) {
 	zoneID, applicationID, err := c.exchanger.identity(ctx)
 	if err != nil {
 		return "", err
 	}
-	key := zoneID + "::" + applicationID + "::" + resourceID + "::" + strings.Join(scopes, " ")
+	sessionLabels := labels
+	if len(sessionLabels) == 0 {
+		sessionLabels = []string{applicationID}
+	}
+	key := zoneID + "::" + applicationID + "::" + resourceID + "::" + strings.Join(scopes, " ") + "::" + strings.Join(sessionLabels, " ") + "::" + strconv.Itoa(mandateTTL)
 	c.governedMu.Lock()
 	if cached, ok := c.governedMandates[key]; ok && time.Until(cached.expiresAt) > governedRefreshMargin {
 		c.governedMu.Unlock()

--- a/packages/sdk/python/caracalai/client.py
+++ b/packages/sdk/python/caracalai/client.py
@@ -1791,7 +1791,11 @@ class Caracal:
         exchanger = self.config.exchanger
         assert exchanger is not None
         zone_id, application_id = exchanger.identity()
-        key = f"{zone_id}::{application_id}::{resource_id}::{' '.join(scopes)}"
+        session_labels = labels if labels else [application_id]
+        key = (
+            f"{zone_id}::{application_id}::{resource_id}::{' '.join(scopes)}::"
+            f"{' '.join(session_labels)}::{mandate_ttl}"
+        )
         cached = self._governed_cached(key)
         if cached is not None:
             return cached

--- a/packages/sdk/python/caracalai/client.py
+++ b/packages/sdk/python/caracalai/client.py
@@ -1667,11 +1667,12 @@ class Caracal:
         upstream (or any absolute URL) are rewritten through the configured
         gateway; requests already addressed to the gateway pass through.
 
-        The mandate is cached per application identity, resource, and scope
-        set, refreshed before expiry with a fresh session cycle; concurrent
-        requests share one in-flight cycle. ``labels`` tag the spawned sessions
-        (default: the application id). ``mandate_ttl_seconds`` bounds each
-        mandate; sessions outlive it by a fixed buffer.
+        The mandate is cached per application identity, resource, scope set,
+        effective labels, and mandate TTL, refreshed before expiry with a
+        fresh session cycle; concurrent requests share one in-flight cycle.
+        ``labels`` tag the spawned sessions (default: the application id).
+        ``mandate_ttl_seconds`` bounds each mandate; sessions outlive it by a
+        fixed buffer.
 
         Requires client-secret credentials."""
         return httpx.AsyncClient(
@@ -1792,9 +1793,10 @@ class Caracal:
         assert exchanger is not None
         zone_id, application_id = exchanger.identity()
         session_labels = labels if labels else [application_id]
+        encoded_labels = json.dumps(session_labels, separators=(",", ":"))
         key = (
             f"{zone_id}::{application_id}::{resource_id}::{' '.join(scopes)}::"
-            f"{' '.join(session_labels)}::{mandate_ttl}"
+            f"{encoded_labels}::{mandate_ttl}"
         )
         cached = self._governed_cached(key)
         if cached is not None:

--- a/packages/sdk/ts/src/client.ts
+++ b/packages/sdk/ts/src/client.ts
@@ -634,12 +634,13 @@ export class Caracal {
    * authority: each mint cycle bootstraps a lifecycle token, spawns a
    * source/target agent session pair, narrows the target to `scopes` on the
    * resource over a delegation edge, and mints the mandate every request
-   * presents at the Gateway. Mandates are cached per resource and scope set
-   * and re-minted on a fresh session pair before expiry; sessions from a
-   * failed cycle are terminated best-effort. Requests already addressed to
-   * the Gateway pass through unchanged; other absolute URLs are rewritten
-   * onto it. When a scope is approval-gated the request rejects with
-   * InteractionRequiredError. Requires a client-secret configuration.
+   * presents at the Gateway. Mandates are cached per resolved identity,
+   * resource, scope set, effective labels, and mandate TTL, then re-minted on
+   * a fresh session pair before expiry; sessions from a failed cycle are
+   * terminated best-effort. Requests already addressed to the Gateway pass
+   * through unchanged; other absolute URLs are rewritten onto it. When a scope
+   * is approval-gated the request rejects with InteractionRequiredError.
+   * Requires a client-secret configuration.
    */
   governedTransport(resourceId: string, opts: GovernedTransportOptions): typeof fetch {
     const exchanger = this.config.exchanger
@@ -674,7 +675,7 @@ export class Caracal {
     const identity = await exchanger.identity()
     const mandateTtl = opts.mandateTtlSeconds ?? GOVERNED_MANDATE_TTL_SECONDS
     const labels = opts.labels ?? [identity.applicationId]
-    const key = `${identity.zoneId}::${identity.applicationId}::${resourceId}::${scopes.join(' ')}::${labels.join(' ')}::${mandateTtl}`
+    const key = `${identity.zoneId}::${identity.applicationId}::${resourceId}::${scopes.join(' ')}::${JSON.stringify(labels)}::${mandateTtl}`
     const cached = this.governedMandates.get(key)
     if (cached && Date.now() / 1000 < cached.expiresAt - GOVERNED_REFRESH_MARGIN_SECONDS) return cached
     const inflight = this.governedInflight.get(key)

--- a/packages/sdk/ts/src/client.ts
+++ b/packages/sdk/ts/src/client.ts
@@ -669,8 +669,12 @@ export class Caracal {
   ): Promise<{ mandate: string; expiresAt: number }> {
     // The cache key carries the acting identity, so a credential re-provisioned into a
     // different zone or application can never be served a mandate minted for the old one.
+    // Labels and TTL also shape the governed cycle, so transports with different
+    // attribution or lifetime requirements must not share a cached mandate.
     const identity = await exchanger.identity()
-    const key = `${identity.zoneId}::${identity.applicationId}::${resourceId}::${scopes.join(' ')}`
+    const mandateTtl = opts.mandateTtlSeconds ?? GOVERNED_MANDATE_TTL_SECONDS
+    const labels = opts.labels ?? [identity.applicationId]
+    const key = `${identity.zoneId}::${identity.applicationId}::${resourceId}::${scopes.join(' ')}::${labels.join(' ')}::${mandateTtl}`
     const cached = this.governedMandates.get(key)
     if (cached && Date.now() / 1000 < cached.expiresAt - GOVERNED_REFRESH_MARGIN_SECONDS) return cached
     const inflight = this.governedInflight.get(key)

--- a/tests/python/unit/caracalai/test_governed_transport.py
+++ b/tests/python/unit/caracalai/test_governed_transport.py
@@ -206,6 +206,33 @@ class GovernedCycleTests(unittest.TestCase):
         self.assertEqual(platform.mints, 1)
         self.assertEqual(platform.spawns, 2)
 
+    def test_cache_separates_different_labels_and_ttls(self) -> None:
+        platform = _Platform()
+        c = _client(platform)
+        with c.sync_governed_transport(
+            RESOURCE,
+            scopes=["data:read"],
+            labels=["worker"],
+            mandate_ttl_seconds=300,
+            transport=httpx.MockTransport(_gateway_echo),
+        ) as client:
+            client.get("http://gateway/worker")
+        with c.sync_governed_transport(
+            RESOURCE,
+            scopes=["data:read"],
+            labels=["admin"],
+            mandate_ttl_seconds=60,
+            transport=httpx.MockTransport(_gateway_echo),
+        ) as client:
+            client.get("http://gateway/admin")
+
+        self.assertEqual(platform.mints, 2)
+        self.assertEqual(platform.spawns, 4)
+        spawns = platform.spawn_calls()
+        self.assertEqual(spawns[2][1]["labels"], ["admin"])
+        self.assertEqual(spawns[2][1]["ttl_seconds"], 180)
+        self.assertEqual(platform.mint_forms()[-1]["ttl_seconds"], ["60"])
+
     def test_concurrent_requests_share_one_cycle(self) -> None:
         platform = _Platform()
         c = _client(platform)

--- a/tests/python/unit/caracalai/test_governed_transport.py
+++ b/tests/python/unit/caracalai/test_governed_transport.py
@@ -220,7 +220,7 @@ class GovernedCycleTests(unittest.TestCase):
         with c.sync_governed_transport(
             RESOURCE,
             scopes=["data:read"],
-            labels=["admin"],
+            labels=["a", "b"],
             mandate_ttl_seconds=60,
             transport=httpx.MockTransport(_gateway_echo),
         ) as client:
@@ -229,7 +229,7 @@ class GovernedCycleTests(unittest.TestCase):
         self.assertEqual(platform.mints, 2)
         self.assertEqual(platform.spawns, 4)
         spawns = platform.spawn_calls()
-        self.assertEqual(spawns[2][1]["labels"], ["admin"])
+        self.assertEqual(spawns[2][1]["labels"], ["a", "b"])
         self.assertEqual(spawns[2][1]["ttl_seconds"], 180)
         self.assertEqual(platform.mint_forms()[-1]["ttl_seconds"], ["60"])
 

--- a/tests/source/go/packages/sdk/go/governed_transport_test.go
+++ b/tests/source/go/packages/sdk/go/governed_transport_test.go
@@ -314,7 +314,7 @@ func TestGovernedTransportCacheSeparatesLabelsAndTTL(t *testing.T) {
 	c := governedClient(t, server.URL, gateway.URL, nil)
 	worker, err := c.GovernedTransport(nil, governedResource, sdk.GovernedTransportOptions{
 		Scopes:            []string{"data:read"},
-		Labels:            []string{"worker"},
+		Labels:            []string{"a b"},
 		MandateTTLSeconds: 300,
 	})
 	if err != nil {
@@ -322,7 +322,7 @@ func TestGovernedTransportCacheSeparatesLabelsAndTTL(t *testing.T) {
 	}
 	admin, err := c.GovernedTransport(nil, governedResource, sdk.GovernedTransportOptions{
 		Scopes:            []string{"data:read"},
-		Labels:            []string{"admin"},
+		Labels:            []string{"a", "b"},
 		MandateTTLSeconds: 60,
 	})
 	if err != nil {
@@ -343,8 +343,8 @@ func TestGovernedTransportCacheSeparatesLabelsAndTTL(t *testing.T) {
 		t.Fatalf("expected 4 spawned sessions, got %d", platform.agentN)
 	}
 	labels, _ := platform.spawnBodies[2]["labels"].([]any)
-	if len(labels) != 1 || labels[0] != "admin" {
-		t.Fatalf("expected second cycle admin labels, got %v", platform.spawnBodies[2]["labels"])
+	if len(labels) != 2 || labels[0] != "a" || labels[1] != "b" {
+		t.Fatalf("expected second cycle split labels, got %v", platform.spawnBodies[2]["labels"])
 	}
 	if platform.spawnBodies[2]["ttl_seconds"] != float64(180) {
 		t.Fatalf("expected second session ttl 180, got %v", platform.spawnBodies[2]["ttl_seconds"])

--- a/tests/source/go/packages/sdk/go/governed_transport_test.go
+++ b/tests/source/go/packages/sdk/go/governed_transport_test.go
@@ -304,6 +304,53 @@ func TestGovernedTransportCachesMandateAcrossRequests(t *testing.T) {
 	}
 }
 
+func TestGovernedTransportCacheSeparatesLabelsAndTTL(t *testing.T) {
+	platform := &governedPlatform{}
+	server := httptest.NewServer(platform.handler())
+	defer server.Close()
+	gateway := governedEcho()
+	defer gateway.Close()
+
+	c := governedClient(t, server.URL, gateway.URL, nil)
+	worker, err := c.GovernedTransport(nil, governedResource, sdk.GovernedTransportOptions{
+		Scopes:            []string{"data:read"},
+		Labels:            []string{"worker"},
+		MandateTTLSeconds: 300,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin, err := c.GovernedTransport(nil, governedResource, sdk.GovernedTransportOptions{
+		Scopes:            []string{"data:read"},
+		Labels:            []string{"admin"},
+		MandateTTLSeconds: 60,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	governedGet(t, worker, governedUpstream+"/worker")
+	governedGet(t, admin, governedUpstream+"/admin")
+
+	if mints := platform.finalMints(); len(mints) != 2 {
+		t.Fatalf("expected 2 provisioning cycles, got %d", len(mints))
+	} else if mints[1].Get("ttl_seconds") != "60" {
+		t.Fatalf("expected second mandate ttl 60, got %v", mints[1])
+	}
+	platform.mu.Lock()
+	defer platform.mu.Unlock()
+	if platform.agentN != 4 {
+		t.Fatalf("expected 4 spawned sessions, got %d", platform.agentN)
+	}
+	labels, _ := platform.spawnBodies[2]["labels"].([]any)
+	if len(labels) != 1 || labels[0] != "admin" {
+		t.Fatalf("expected second cycle admin labels, got %v", platform.spawnBodies[2]["labels"])
+	}
+	if platform.spawnBodies[2]["ttl_seconds"] != float64(180) {
+		t.Fatalf("expected second session ttl 180, got %v", platform.spawnBodies[2]["ttl_seconds"])
+	}
+}
+
 func TestGovernedTransportSharesConcurrentCycle(t *testing.T) {
 	platform := &governedPlatform{}
 	server := httptest.NewServer(platform.handler())

--- a/tests/typescript/unit/sdk/governed-transport.test.ts
+++ b/tests/typescript/unit/sdk/governed-transport.test.ts
@@ -141,6 +141,28 @@ describe('Caracal.governedTransport', () => {
     expect(counters.spawn).toBe(2)
   })
 
+  it('does not share cached mandates across different labels or TTLs', async () => {
+    const { fetchImpl, calls, counters } = fakeFetch()
+    const caracal = client(fetchImpl)
+    const worker = caracal.governedTransport(RESOURCE, { scopes: ['data:read'], labels: ['worker'], mandateTtlSeconds: 300 })
+    const admin = caracal.governedTransport(RESOURCE, { scopes: ['data:read'], labels: ['admin'], mandateTtlSeconds: 60 })
+
+    await worker(`${GATEWAY}/worker`, { method: 'POST', body: '{}' })
+    await admin(`${GATEWAY}/admin`, { method: 'POST', body: '{}' })
+
+    expect(counters.mint).toBe(2)
+    expect(counters.spawn).toBe(4)
+    const spawnBodies = calls.filter((c) => c.url.endsWith('/agents')).map((c) => JSON.parse(c.body!))
+    expect(spawnBodies[2].labels).toEqual(['admin'])
+    expect(spawnBodies[2].ttl_seconds).toBe(180)
+    const finalMint = calls
+      .filter((c) => c.url === `${STS}/oauth/2/token`)
+      .map((c) => new URLSearchParams(c.body!))
+      .filter((form) => form.get('scope') === 'data:read')
+      .at(-1)!
+    expect(finalMint.get('ttl_seconds')).toBe('60')
+  })
+
   it('dedups concurrent first calls into a single mint cycle', async () => {
     const { fetchImpl, counters } = fakeFetch()
     const governed = client(fetchImpl).governedTransport(RESOURCE, { scopes: ['data:read'] })

--- a/tests/typescript/unit/sdk/governed-transport.test.ts
+++ b/tests/typescript/unit/sdk/governed-transport.test.ts
@@ -144,8 +144,8 @@ describe('Caracal.governedTransport', () => {
   it('does not share cached mandates across different labels or TTLs', async () => {
     const { fetchImpl, calls, counters } = fakeFetch()
     const caracal = client(fetchImpl)
-    const worker = caracal.governedTransport(RESOURCE, { scopes: ['data:read'], labels: ['worker'], mandateTtlSeconds: 300 })
-    const admin = caracal.governedTransport(RESOURCE, { scopes: ['data:read'], labels: ['admin'], mandateTtlSeconds: 60 })
+    const worker = caracal.governedTransport(RESOURCE, { scopes: ['data:read'], labels: ['a b'], mandateTtlSeconds: 300 })
+    const admin = caracal.governedTransport(RESOURCE, { scopes: ['data:read'], labels: ['a', 'b'], mandateTtlSeconds: 60 })
 
     await worker(`${GATEWAY}/worker`, { method: 'POST', body: '{}' })
     await admin(`${GATEWAY}/admin`, { method: 'POST', body: '{}' })
@@ -153,7 +153,7 @@ describe('Caracal.governedTransport', () => {
     expect(counters.mint).toBe(2)
     expect(counters.spawn).toBe(4)
     const spawnBodies = calls.filter((c) => c.url.endsWith('/agents')).map((c) => JSON.parse(c.body!))
-    expect(spawnBodies[2].labels).toEqual(['admin'])
+    expect(spawnBodies[2].labels).toEqual(['a', 'b'])
     expect(spawnBodies[2].ttl_seconds).toBe(180)
     const finalMint = calls
       .filter((c) => c.url === `${STS}/oauth/2/token`)


### PR DESCRIPTION
## Summary

Governed transport mandate caching currently keys only on the resolved identity, resource, and scopes. This means two governed transports with the same resource/scopes but different `labels` or mandate TTL can accidentally share the same cached mandate.

This updates the governed mandate cache key across the TypeScript, Python, and Go SDKs to include the effective labels and mandate TTL, so transports with different attribution or lifetime requirements get separate governed cycles.

## Changes

- Include effective labels and mandate TTL in governed transport cache keys
- Preserve the existing default label behavior by keying unset labels as the application id
- Add regression coverage in TS, Python, and Go showing different labels/TTLs trigger separate governed cycles

## Testing

- `packages\sdk\ts\node_modules\.bin\vitest.CMD run --root . tests\typescript\unit\sdk\governed-transport.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed governed-transport mandate caching to prevent reuse across different effective label sets and mandate TTL values, avoiding collisions between otherwise similar requests.
  * Ensured cached provisioning reflects the correct label configuration and the required token lifetime for each transport.
* **Documentation**
  * Updated governed-transport guidance to clarify that caching includes effective session labels and mandate TTL.
* **Tests**
  * Added unit tests in Go, Python, and TypeScript to verify cache separation for differing labels and TTLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->