### PR TITLE
fix(ts-sdk): contain gateway authority to base path

### DIFF
--- a/packages/sdk/ts/src/client.ts
+++ b/packages/sdk/ts/src/client.ts
@@ -1204,7 +1204,8 @@ export class Caracal {
     } catch {
       return null
     }
-    if (sameOrigin(parsed, gw)) return { url: parsed.toString(), resourceId: explicitResource ?? '' }
+    if (pathContainsTraversal(parsed.pathname)) return null
+    if (targetsGatewayPath(parsed, gw)) return { url: parsed.toString(), resourceId: explicitResource ?? '' }
     const binding = explicitResource
       ? this.config.resources?.find((b) => b.resourceId === explicitResource)
       : this.config.resources?.find((b) => urlMatchesPrefix(parsed, b.upstreamPrefix))
@@ -1230,7 +1231,7 @@ export class Caracal {
     if (!gw) return false
     const raw = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url
     try {
-      return sameOrigin(new URL(raw), gw)
+      return targetsGatewayPath(new URL(raw), gw)
     } catch {
       return false
     }
@@ -1812,13 +1813,33 @@ function resourcesFromCredentials(credentials: CredentialEntry[]): ProfileResour
   return { resources: values, bindings }
 }
 
-function sameOrigin(a: URL, b: string): boolean {
+function targetsGatewayPath(target: URL, gatewayUrl: string): boolean {
+  let gateway: URL
   try {
-    const o = new URL(b)
-    return a.protocol === o.protocol && a.host === o.host
+    gateway = new URL(gatewayUrl)
   } catch {
     return false
   }
+  if (target.protocol !== gateway.protocol || target.host !== gateway.host) return false
+  if (pathContainsTraversal(target.pathname)) return false
+  const base = gateway.pathname.replace(/\/$/, '') || '/'
+  return base === '/' || target.pathname === base || target.pathname.startsWith(`${base}/`)
+}
+
+function pathContainsTraversal(pathname: string): boolean {
+  let decoded = pathname
+  for (let i = 0; i < 8; i += 1) {
+    if (decoded.includes('\\') || decoded.split('/').some((segment) => segment === '.' || segment === '..')) return true
+    let next: string
+    try {
+      next = decodeURIComponent(decoded)
+    } catch {
+      return true
+    }
+    if (next === decoded) return false
+    decoded = next
+  }
+  return true
 }
 
 function joinGatewayPath(gatewayUrl: string, path: string): string {
@@ -1832,7 +1853,7 @@ function joinGatewayPath(gatewayUrl: string, path: string): string {
   const query = queryIndex === -1 ? '' : normalized.slice(queryIndex + 1)
   // Dot segments could climb out of a base-pathed gateway once the URL
   // normalizes, so the path must arrive already resolved.
-  if (pathname.split('/').some((segment) => segment === '.' || segment === '..')) {
+  if (pathContainsTraversal(pathname)) {
     throw new Error('Caracal.gatewayRequest(): path must not contain dot segments')
   }
   const base = gateway.origin + gateway.pathname.replace(/\/$/, '')

--- a/packages/sdk/ts/src/client.ts
+++ b/packages/sdk/ts/src/client.ts
@@ -1220,7 +1220,7 @@ export class Caracal {
         if (!suffix.startsWith('/')) suffix = '/' + suffix
       }
     }
-    const base = gateway.origin + gateway.pathname.replace(/\/$/, '')
+    const base = gateway.origin + gateway.pathname.replace(/\/+$/, '')
     const target = base + suffix
     return { url: target, resourceId: binding?.resourceId ?? explicitResource! }
   }
@@ -1822,7 +1822,7 @@ function targetsGatewayPath(target: URL, gatewayUrl: string): boolean {
   }
   if (target.protocol !== gateway.protocol || target.host !== gateway.host) return false
   if (pathContainsTraversal(target.pathname)) return false
-  const base = gateway.pathname.replace(/\/$/, '') || '/'
+  const base = gateway.pathname.replace(/\/+$/, '') || '/'
   return base === '/' || target.pathname === base || target.pathname.startsWith(`${base}/`)
 }
 
@@ -1856,7 +1856,7 @@ function joinGatewayPath(gatewayUrl: string, path: string): string {
   if (pathContainsTraversal(pathname)) {
     throw new Error('Caracal.gatewayRequest(): path must not contain dot segments')
   }
-  const base = gateway.origin + gateway.pathname.replace(/\/$/, '')
+  const base = gateway.origin + gateway.pathname.replace(/\/+$/, '')
   return `${base}${pathname || '/'}${query ? `?${query}` : ''}`
 }
 

--- a/tests/typescript/unit/sdk/client.test.ts
+++ b/tests/typescript/unit/sdk/client.test.ts
@@ -616,12 +616,33 @@ describe('caracal.transport', () => {
 
     await send('https://gateway.example.com/unrelated')
     await send('https://gateway.example.com/proxy/%252e%252e/admin')
+    await send('https://gateway.example.com/proxy/..%2fadmin')
+    await send('https://gateway.example.com/proxyEVIL/admin')
 
     for (const call of calls) {
       expect(call.headers.get(HeaderAuthorization)).toBeNull()
       expect(call.headers.get(HeaderTraceparent)).toBeNull()
       expect(call.headers.get(HeaderBaggage)).toBeNull()
     }
+  })
+
+  it('attaches authority to in-mount paths and tolerates redundant gateway trailing slashes', async () => {
+    const calls: { url: string; headers: Headers }[] = []
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      calls.push({ url: String(input), headers: new Headers(init.headers) })
+      return new Response(null, { status: 204 })
+    }) as unknown as typeof fetch
+    const c = new Caracal({
+      ...baseConfig,
+      coordinator: { baseUrl: 'http://c', fetchImpl: fakeFetch },
+      gatewayUrl: 'https://gateway.example.com/proxy//',
+    })
+
+    await c.transport({ asApplication: true })('https://gateway.example.com/proxy/v1/models')
+
+    expect(calls[0].url).toBe('https://gateway.example.com/proxy/v1/models')
+    expect(calls[0].headers.get(HeaderAuthorization)).toBe('Bearer tok')
+    expect(parseTraceparent(calls[0].headers.get(HeaderTraceparent)!)).toBeTruthy()
   })
 
   it('routes bound provider calls through the configured gateway', async () => {

--- a/tests/typescript/unit/sdk/client.test.ts
+++ b/tests/typescript/unit/sdk/client.test.ts
@@ -601,6 +601,29 @@ describe('caracal.transport', () => {
     expect(parseTraceparent(calls[1].headers.get(HeaderTraceparent)!)).toBeTruthy()
   })
 
+  it('keeps authority off same-origin paths outside the gateway base path', async () => {
+    const calls: { url: string; headers: Headers }[] = []
+    const fakeFetch = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      calls.push({ url: String(input), headers: new Headers(init.headers) })
+      return new Response(null, { status: 204 })
+    }) as unknown as typeof fetch
+    const c = new Caracal({
+      ...baseConfig,
+      coordinator: { baseUrl: 'http://c', fetchImpl: fakeFetch },
+      gatewayUrl: 'https://gateway.example.com/proxy',
+    })
+    const send = c.transport({ asApplication: true, propagation: 'gateway-only' })
+
+    await send('https://gateway.example.com/unrelated')
+    await send('https://gateway.example.com/proxy/%252e%252e/admin')
+
+    for (const call of calls) {
+      expect(call.headers.get(HeaderAuthorization)).toBeNull()
+      expect(call.headers.get(HeaderTraceparent)).toBeNull()
+      expect(call.headers.get(HeaderBaggage)).toBeNull()
+    }
+  })
+
   it('routes bound provider calls through the configured gateway', async () => {
     const calls: { url: string; headers: Headers }[] = []
     const fakeFetch = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {


### PR DESCRIPTION
## Summary
- tighten TypeScript SDK Gateway-bound URL detection to require the configured Gateway base path, not just same origin
- reject traversal-shaped Gateway paths before attaching Caracal authority
- add a regression test covering same-origin paths outside the Gateway mount

## Why
When `gatewayUrl` includes a base path, such as `https://gateway.example.com/proxy`, the TypeScript SDK previously treated any same-origin URL as Gateway-bound.

That means a request to `https://gateway.example.com/unrelated` could receive Caracal authority headers even though it is outside the configured Gateway path. Go and Python already guard this by checking the Gateway base path.

## Testing
- `packages\sdk\ts\node_modules\.bin\vitest.CMD run --root . tests/typescript/unit/sdk/client.test.ts`
- `packages\sdk\ts\node_modules\.bin\vitest.CMD run --root . tests/typescript/unit/sdk/application-transport.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway URL routing with stronger path traversal protections, including encoded/double-encoded variants.
  * Enforced correct gateway base-path handling so gateway-only requests outside the configured base path do not include authority/tracing headers.
  * Correctly routes requests when targeting paths under the gateway base path, including when the gateway URL has redundant trailing slashes.
* **Tests**
  * Added coverage to verify header presence/absence for in-scope vs out-of-scope gateway URLs, including traversal-like cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->