### PR TITLE
Fix ts empty application labels

### DIFF
--- a/packages/sdk/ts/src/client.ts
+++ b/packages/sdk/ts/src/client.ts
@@ -1144,7 +1144,7 @@ export class Caracal {
     const spawnReq = {
       zoneId: identity.zoneId,
       applicationId: identity.applicationId,
-      labels: opts.labels ?? [identity.applicationId],
+      labels: opts.labels,
       ttlSeconds: sessionTtl,
     }
     const sessions: string[] = []

--- a/packages/sdk/ts/src/client.ts
+++ b/packages/sdk/ts/src/client.ts
@@ -1036,7 +1036,7 @@ export class Caracal {
     this.ensureOpen()
     const credentialGeneration = identity.credentialGeneration ?? ''
     const mandateTtl = opts.mandateTtlSeconds ?? APP_MANDATE_TTL_SECONDS
-    const labels = opts.labels ?? [identity.applicationId]
+    const labels = opts.labels?.length ? opts.labels : [identity.applicationId]
     const stale: AppAuthorityEntry[] = []
     const now = Date.now() / 1000
     for (const [cachedKey, entry] of this.appAuthorities) {
@@ -1062,7 +1062,7 @@ export class Caracal {
     const pending = (async () => {
       try {
         const fresh = await this.withAppProvisioning(signal, () =>
-          this.appAuthorityCycle(exchanger, identity, resourceId, scopes, opts, signal),
+          this.appAuthorityCycle(exchanger, identity, resourceId, scopes, { ...opts, labels }, signal),
         )
         if (generation !== this.appGeneration) {
           await this.retireAppAuthorities(exchanger, [fresh])

--- a/tests/typescript/unit/sdk/application-transport.test.ts
+++ b/tests/typescript/unit/sdk/application-transport.test.ts
@@ -156,6 +156,17 @@ describe('Caracal.applicationTransport', () => {
     expect(mint.get('subject_token')).toBeNull()
   })
 
+  it('defaults explicit empty labels to the application id for both sessions', async () => {
+    const { fetchImpl, calls } = fakeFetch()
+    const appFetch = client(fetchImpl).applicationTransport(RESOURCE, { scopes: ['data:read'], labels: [] })
+
+    await appFetch(`${GATEWAY}/v1/things`, { method: 'POST', body: '{}' })
+
+    const spawns = calls.filter((call) => call.url.endsWith('/agents') && call.method === 'POST')
+    expect(spawns).toHaveLength(2)
+    for (const spawn of spawns) expect(JSON.parse(spawn.body!).labels).toEqual(['app-1'])
+  })
+
   it('close terminates the sessions backing cached mandates', async () => {
     const { fetchImpl, calls } = fakeFetch()
     const c = client(fetchImpl)


### PR DESCRIPTION
## Summary

- treat an explicit empty `labels` array in the TypeScript application transport the same as omitted labels
- default effective labels to the application ID, matching the Python and Go SDKs
- use the normalized labels for both authority cache identity and Coordinator session provisioning
- add a regression test covering both source and target sessions

## Problem

Application transport labels default to the application ID so that sessions align with the default role created by grant helpers.

Python and Go apply this default when labels are omitted or empty. TypeScript previously used nullish coalescing, so `labels: []` remained empty.

This could cause an otherwise valid application transport to be denied because its sessions did not carry the application-ID role expected by the grant.

## Testing

- `vitest run --root . tests/typescript/unit/sdk/application-transport.test.ts`
  - 22 tests passed
- `vitest run --root . tests/typescript/unit/sdk`
  - 244 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected application transport label handling so explicitly providing an empty label list is preserved instead of being replaced by the default application label.
  * Ensured consistent label values are applied when spawning source, target, and coordinator sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->