### PR TITLE
fix(runtime): exit cleanly after readiness checks

### DIFF
--- a/apps/runtime/src/commands/stack.ts
+++ b/apps/runtime/src/commands/stack.ts
@@ -167,8 +167,11 @@ export async function upCommand(argv: string[]): Promise<void> {
       await completeRuntimeOnboarding()
     } catch (err) {
       printError(err instanceof Error ? err.message : String(err))
-      process.exit(1)
+      process.exitCode = 1
+      return
     }
+    process.exitCode = 0
+    return
   }
   process.exit(code)
 }
@@ -240,10 +243,11 @@ export async function upgradeCommand(argv: string[]): Promise<void> {
   } catch (err) {
     printError(err instanceof Error ? err.message : String(err))
     record('readinessFailed')
-    process.exit(1)
+    process.exitCode = 1
+    return
   }
   record('success')
-  process.exit(0)
+  process.exitCode = 0
 }
 
 function upgradeHelp(): never {

--- a/tests/typescript/unit/runtime/stack-command.test.ts
+++ b/tests/typescript/unit/runtime/stack-command.test.ts
@@ -42,6 +42,7 @@ describe('stack commands', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    process.exitCode = undefined
     stderr = ''
     stdout = ''
     xdg = mkdtempSync(join(tmpdir(), 'caracal-stack-command-'))
@@ -73,6 +74,7 @@ describe('stack commands', () => {
   })
 
   afterEach(() => {
+    process.exitCode = undefined
     vi.restoreAllMocks()
     vi.unstubAllEnvs()
     rmSync(xdg, { recursive: true, force: true })
@@ -177,8 +179,10 @@ describe('stack commands', () => {
   })
 
   it('reports services ready without creating runtime config after a full stack start', async () => {
-    await expect(upCommand([])).rejects.toThrow('exit:0')
+    await expect(upCommand([])).resolves.toBeUndefined()
 
+    expect(process.exit).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(0)
     expect(engineMocks.stackStatus).toHaveBeenCalledWith({
       probes: [],
     })
@@ -186,6 +190,16 @@ describe('stack commands', () => {
     expect(stdout).toContain('runtime services ready')
     expect(stdout).not.toContain('runtime onboarding complete')
     expect(stdout).not.toContain('runtime config not found')
+  })
+
+  it('returns naturally when full-stack readiness fails', async () => {
+    engineMocks.stackStatus.mockRejectedValue(new Error('readiness probe failed'))
+
+    await expect(upCommand([])).resolves.toBeUndefined()
+
+    expect(process.exit).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+    expect(stderr).toContain('readiness probe failed')
   })
 
   it('forwards BuildKit env to compose when starting the stack', async () => {
@@ -215,8 +229,10 @@ describe('stack commands', () => {
   })
 
   it('upgrade stages images, migrates expand-first, rolls, then gates readiness', async () => {
-    await expect(upgradeCommand([])).rejects.toThrow('exit:0')
+    await expect(upgradeCommand([])).resolves.toBeUndefined()
 
+    expect(process.exit).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(0)
     const calls = engineMocks.composeRun.mock.calls.map((c) => (c[0] as { args: string[] }).args)
     expect(calls).toContainEqual(['build'])
     const migrateIndex = calls.findIndex((a) => a[0] === 'run' && a.includes('dbMigrate'))
@@ -235,7 +251,7 @@ describe('stack commands', () => {
       secretsDir: '/tmp/caracal-secrets',
     })
 
-    await expect(upgradeCommand([])).rejects.toThrow('exit:0')
+    await expect(upgradeCommand([])).resolves.toBeUndefined()
 
     const calls = engineMocks.composeRun.mock.calls.map((c) => (c[0] as { args: string[] }).args)
     expect(calls).toContainEqual(['pull'])
@@ -245,10 +261,20 @@ describe('stack commands', () => {
   })
 
   it('upgrade skips the lock and journal in dev mode', async () => {
-    await expect(upgradeCommand([])).rejects.toThrow('exit:0')
+    await expect(upgradeCommand([])).resolves.toBeUndefined()
 
     expect(engineMocks.acquireStackLock).not.toHaveBeenCalled()
     expect(engineMocks.appendUpgradeRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns naturally when upgrade readiness fails', async () => {
+    engineMocks.stackStatus.mockRejectedValue(new Error('readiness probe failed'))
+
+    await expect(upgradeCommand([])).resolves.toBeUndefined()
+
+    expect(process.exit).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+    expect(stderr).toContain('readiness probe failed')
   })
 
   it('upgrade aborts before rolling services when the migration fails', async () => {


### PR DESCRIPTION
## Summary

- allow full-stack `up` and `upgrade` commands to return naturally after asynchronous readiness checks
- preserve success and failure status through `process.exitCode`
- add regression coverage for successful and failed readiness paths
- retain the existing immediate-exit behavior for early failures and targeted stack commands

## Problem

On Windows, `pnpm caracal up` successfully started the stack and completed all readiness probes, but the CLI then terminated with a native libuv assertion:

```text
runtime services ready
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime stack startup and upgrade handling when onboarding or readiness checks fail.
  * Commands now complete cleanly while reporting success or failure status accurately.
  * Preserved clear error messaging for readiness and onboarding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->