### PR TITLE
fix: support spaces in Windows setup paths

### DIFF
--- a/scripts/setupDev.mjs
+++ b/scripts/setupDev.mjs
@@ -11,8 +11,7 @@ import { fileURLToPath } from 'node:url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const isWindows = process.platform === 'win32'
-const python =
-  process.env.PYTHON || (spawnSync('python3', ['--version'], { stdio: 'ignore', shell: isWindows }).status === 0 ? 'python3' : 'python')
+const python = process.env.PYTHON || (spawnSync('python3', ['--version'], { stdio: 'ignore' }).status === 0 ? 'python3' : 'python')
 const venvDir = process.env.CARACAL_DEV_VENV || '.venv'
 const venvPython = join(root, venvDir, isWindows ? 'Scripts/python.exe' : 'bin/python')
 const editablePackages = [
@@ -30,14 +29,13 @@ function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: root,
     stdio: 'inherit',
-    shell: isWindows,
     ...options,
   })
   if (result.error) throw result.error
   if (result.status !== 0) process.exit(result.status ?? 1)
 }
 
-run('pnpm', ['install', '--frozen-lockfile'])
+run('pnpm', ['install', '--frozen-lockfile'], { shell: isWindows })
 run('git', ['config', 'core.hooksPath', '.githooks'])
 run('go', ['mod', 'download'])
 

--- a/tests/typescript/unit/runtime/setupDev.test.ts
+++ b/tests/typescript/unit/runtime/setupDev.test.ts
@@ -50,7 +50,7 @@ describe('developer setup', () => {
   })
 
   it('uses the configured Python executable directly', async () => {
-    process.env.PYTHON = 'C:\Program Files\Python\python.exe'
+    process.env.PYTHON = String.raw`C:\Program Files\Python\python.exe`
     existsSyncMock.mockReturnValue(false)
 
     await import('../../../../scripts/setupDev.mjs')

--- a/tests/typescript/unit/runtime/setupDev.test.ts
+++ b/tests/typescript/unit/runtime/setupDev.test.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Developer setup tests cover portable child process execution.
+
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const spawnSyncMock = vi.hoisted(() => vi.fn(() => ({ status: 0 })))
+const existsSyncMock = vi.hoisted(() => vi.fn(() => true))
+const platform = process.platform
+
+vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }))
+vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
+
+describe('developer setup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+    vi.restoreAllMocks()
+  })
+
+  it('runs Windows executable paths directly and shells only pnpm', async () => {
+    await import('../../../../scripts/setupDev.mjs')
+
+    const root = resolve(import.meta.dirname, '../../../..')
+    const venvPython = join(root, '.venv', 'Scripts/python.exe')
+    const venvCalls = spawnSyncMock.mock.calls.filter(([command]) => command === venvPython)
+
+    expect(venvCalls).toHaveLength(3)
+    for (const call of venvCalls) expect(call[2]).not.toHaveProperty('shell')
+    expect(spawnSyncMock).toHaveBeenCalledWith('pnpm', ['install', '--frozen-lockfile'], expect.objectContaining({ shell: true }))
+    for (const command of ['git', 'go']) {
+      const call = spawnSyncMock.mock.calls.find(([spawned]) => spawned === command)
+      expect(call?.[2]).not.toHaveProperty('shell')
+    }
+  })
+})

--- a/tests/typescript/unit/runtime/setupDev.test.ts
+++ b/tests/typescript/unit/runtime/setupDev.test.ts
@@ -9,20 +9,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const spawnSyncMock = vi.hoisted(() => vi.fn(() => ({ status: 0 })))
 const existsSyncMock = vi.hoisted(() => vi.fn(() => true))
 const platform = process.platform
+const environment = { ...process.env }
 
 vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }))
 vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
 
 describe('developer setup', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    spawnSyncMock.mockReset()
+    spawnSyncMock.mockReturnValue({ status: 0 })
+    existsSyncMock.mockReset()
+    existsSyncMock.mockReturnValue(true)
     vi.resetModules()
+    process.env = { ...environment }
+    delete process.env.PYTHON
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     vi.spyOn(console, 'log').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+    process.env = { ...environment }
     vi.restoreAllMocks()
   })
 
@@ -40,5 +47,26 @@ describe('developer setup', () => {
       const call = spawnSyncMock.mock.calls.find(([spawned]) => spawned === command)
       expect(call?.[2]).not.toHaveProperty('shell')
     }
+  })
+
+  it('uses the configured Python executable directly', async () => {
+    process.env.PYTHON = 'C:\Program Files\Python\python.exe'
+    existsSyncMock.mockReturnValue(false)
+
+    await import('../../../../scripts/setupDev.mjs')
+
+    expect(spawnSyncMock).not.toHaveBeenCalledWith('python3', ['--version'], expect.anything())
+    expect(spawnSyncMock).toHaveBeenCalledWith(process.env.PYTHON, ['-m', 'venv', '.venv'], expect.not.objectContaining({ shell: true }))
+  })
+
+  it('falls back to Python when python3 is unavailable', async () => {
+    existsSyncMock.mockReturnValue(false)
+    spawnSyncMock.mockImplementation((command, args) => ({
+      status: command === 'python3' && args[0] === '--version' ? 1 : 0,
+    }))
+
+    await import('../../../../scripts/setupDev.mjs')
+
+    expect(spawnSyncMock).toHaveBeenCalledWith('python', ['-m', 'venv', '.venv'], expect.not.objectContaining({ shell: true }))
   })
 })


### PR DESCRIPTION
## PR Title

fix: support spaces in Windows setup paths

## Summary

Runs setup executables directly instead of routing every child process through the Windows shell, preventing paths containing spaces from being split. Retains shell handling for the pnpm Windows command shim and adds regression coverage for the setup process.

## Related Issue

Fixes #364

## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [x] Local run
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes:

- `pnpm run setup`
- `pnpm exec vitest run tests/typescript/unit/runtime/setupDev.test.ts`
- `pnpm --dir apps/runtime test`
  - 25 test files passed
  - 270 tests passed
  - 2 tests skipped
- `pnpm run style`
- Tested from `C:\Users\Shubham Sharma\Downloads\caracal`, which contains a space in the user profile path.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

## Screenshots / Demos (if UI or UX)

Not applicable. This change affects the CLI setup process.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Major new functionality includes automated tests (required)
- [x] Bug fixes include a regression test (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved developer setup command handling on Windows.
  * Ensured shell-specific execution is applied only to package installation, improving compatibility for other setup commands.

* **Tests**
  * Added automated coverage to verify Windows executable and shell behavior during developer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->