### PR TITLE
fix: stop mid-stream failover from corrupting the Operator answer stream

### DIFF
--- a/apps/api/src/operator-gateway.ts
+++ b/apps/api/src/operator-gateway.ts
@@ -155,6 +155,21 @@ export class GatewayBudgetError extends Error {
   }
 }
 
+// A streaming provider failed after it had already emitted at least one delta to the client. Those
+// deltas are on the client's screen, so failing over to another provider would append a second
+// answer to a half-written one. This ends the failover instead: the gateway re-raises it rather
+// than trying the next provider, and the turn terminates rather than corrupting the visible stream.
+// It carries the interrupted provider and the redacted failure reason.
+export class GatewayStreamInterruptedError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly reason: string,
+  ) {
+    super(`streaming provider ${provider} failed after output began: ${reason}`)
+    this.name = 'GatewayStreamInterruptedError'
+  }
+}
+
 type FetchImpl = typeof fetch
 
 // The OpenAI-compatible provider emits one benign warning on every structured
@@ -353,9 +368,11 @@ async function callProvider(
 // Performs one streaming free-text chat completion against a single provider. It emits each text
 // and reasoning delta to the handlers as it arrives, then returns the same CompletionResult the
 // non-streaming path would, so a caller gets a live preview and the authoritative final text from
-// one call. Per-call retry is disabled so this gateway's own failover order owns retry semantics; a
-// provider that fails before the first delta fails over cleanly, and an empty completion throws
-// like the non-streaming path.
+// one call. Per-call retry is disabled so this gateway's own failover order owns retry semantics. A
+// provider that fails before the first delta fails over cleanly like the non-streaming path; a
+// provider that fails after a delta has reached the client cannot fail over without appending a
+// second answer to the partial one already on screen, so it raises a GatewayStreamInterruptedError
+// the failover order re-raises rather than retries.
 async function callProviderStream(
   fetchImpl: FetchImpl,
   provider: ProviderConfig,
@@ -366,6 +383,10 @@ async function callProviderStream(
 ): Promise<CompletionResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), provider.timeoutMs)
+  // Whether any delta has reached the client. Once it has, the partial answer is visible, so a
+  // later failure ends the turn rather than failing over; before it has, the failure is invisible
+  // and fails over cleanly.
+  let emitted = false
   try {
     const { system, conversation } = splitSystem(messages)
     const result = streamText({
@@ -384,10 +405,19 @@ async function callProviderStream(
     // Read the full stream so both channels surface live: a text-delta is the answer typed out and
     // a reasoning-delta is the model's chain of thought as it works. Both the reasoning_content
     // channel and inline <think> blocks arrive here as reasoning-delta parts, so the caller can
-    // show the thinking while the model reasons instead of waiting for the answer to begin.
+    // show the thinking while the model reasons instead of waiting for the answer to begin. An
+    // error part is a mid-stream provider failure; it throws so the catch below decides whether the
+    // turn can still fail over.
     for await (const part of result.fullStream) {
-      if (part.type === 'text-delta' && part.text.length > 0) handlers.onText(part.text)
-      else if (part.type === 'reasoning-delta' && part.text.length > 0) handlers.onReasoning?.(part.text)
+      if (part.type === 'text-delta' && part.text.length > 0) {
+        emitted = true
+        handlers.onText(part.text)
+      } else if (part.type === 'reasoning-delta' && part.text.length > 0) {
+        emitted = true
+        handlers.onReasoning?.(part.text)
+      } else if (part.type === 'error') {
+        throw part.error
+      }
     }
     const text = (await result.text).trim()
     if (text.length === 0) throw new Error('provider returned an empty completion')
@@ -401,6 +431,12 @@ async function callProviderStream(
       promptTokens: usage.inputTokens,
       completionTokens: usage.outputTokens,
     }
+  } catch (err) {
+    // A failure after the first delta cannot fail over: another provider would append its answer to
+    // the partial one already on the client. It is raised as a non-failover error so the gateway
+    // ends the turn instead of retrying, and the route closes the stream with an interruption frame.
+    if (emitted) throw new GatewayStreamInterruptedError(provider.id, failureReason(err))
+    throw err
   } finally {
     clearTimeout(timeout)
   }
@@ -481,6 +517,9 @@ async function runWithFailover<T>(
     try {
       return await call(provider)
     } catch (err) {
+      // A stream that already reached the client cannot be retried on another provider without
+      // corrupting the visible output, so this failure ends the turn instead of failing over.
+      if (err instanceof GatewayStreamInterruptedError) throw err
       attempts.push({ provider: provider.id, reason: failureReason(err) })
     }
   }

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -45,6 +45,7 @@ import {
   GatewayUnavailableError,
   GatewayError,
   GatewayBudgetError,
+  GatewayStreamInterruptedError,
   type Gateway,
   type ProviderConfig,
 } from '../operator-gateway.js'
@@ -2582,6 +2583,15 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
           502,
           { error: 'ai_unreachable', attempts: err.attempts },
           { state: 'failed', reason: 'ai_unreachable', errorCode: 'ai_unreachable' },
+        )
+      // A provider dropped after it had already streamed part of the answer. Failing over would
+      // append a second provider's answer to the partial one on screen, so the turn ends instead:
+      // the stream closes with an interruption frame rather than silently restarting elsewhere.
+      if (err instanceof GatewayStreamInterruptedError)
+        return finish(
+          502,
+          { error: 'ai_stream_interrupted', provider: err.provider },
+          { state: 'failed', reason: 'ai_stream_interrupted', errorCode: 'ai_stream_interrupted' },
         )
       // An unexpected failure on the stream has already taken over the response, so it cannot fall
       // through to the framework's error handler; it is closed as a terminal error frame. Durable

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -12,6 +12,7 @@ import {
   GatewayUnavailableError,
   GatewayError,
   GatewayBudgetError,
+  GatewayStreamInterruptedError,
   type ProviderConfig,
 } from '../../../../apps/api/src/operator-gateway.js'
 import { ProposedPlan } from '../../../../apps/api/src/operator-capabilities.js'
@@ -37,6 +38,35 @@ function streamResponse(parts: string[], usage?: { prompt_tokens: number; comple
     status: 200,
     headers: { 'content-type': 'text/event-stream' },
   })
+}
+
+// Builds a streaming response that delivers one delta and then the connection drops: the frame
+// feeds the word-smoothing transform so at least one word reaches the handler before the body
+// errors, modeling a provider that fails mid-response after the client has already seen output. The
+// delta key selects the channel - content for the answer, reasoning_content for the chain of thought.
+function midStreamErrorResponse(delta: { content?: string; reasoning_content?: string }): Response {
+  const enc = new TextEncoder()
+  const frame = `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason: null }] })}\n\n`
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(enc.encode(frame))
+      // Give the smoothing transform time to flush the delivered words before the tear.
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      controller.error(new Error('connection reset'))
+    },
+  })
+  return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+}
+
+// Builds a streaming response whose body drops before delivering any delta, modeling a provider
+// that fails at the very start of the response.
+function preEmitErrorResponse(): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.error(new Error('connection refused'))
+    },
+  })
+  return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } })
 }
 
 describe('gateway status', () => {
@@ -397,6 +427,51 @@ describe('gateway stream', () => {
     const result = await gateway.stream([{ role: 'user', content: 'hi' }], { onText: (chunk) => deltas.push(chunk) })
     expect(result.provider).toBe('secondary')
     expect(deltas.join('')).toBe('done')
+  })
+
+  it('terminates the turn instead of failing over once a delta has streamed', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(midStreamErrorResponse({ content: 'Hello world ' }))
+      .mockResolvedValueOnce(streamResponse(['second provider answer']))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    const deltas: string[] = []
+    const error = await gateway.stream([{ role: 'user', content: 'hi' }], { onText: (chunk) => deltas.push(chunk) }).catch((e) => e)
+    expect(error).toBeInstanceOf(GatewayStreamInterruptedError)
+    expect(error.provider).toBe('primary')
+    // The client already saw the primary's partial answer, so the secondary is never called and its
+    // answer can never append to the corrupted stream.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(deltas.length).toBeGreaterThan(0)
+  })
+
+  it('terminates the turn when only a reasoning delta streamed before the failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(midStreamErrorResponse({ reasoning_content: 'weighing the options ' }))
+      .mockResolvedValueOnce(streamResponse(['second provider answer']))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    const reasoning: string[] = []
+    const error = await gateway
+      .stream([{ role: 'user', content: 'why' }], { onText: () => {}, onReasoning: (chunk) => reasoning.push(chunk) })
+      .catch((e) => e)
+    expect(error).toBeInstanceOf(GatewayStreamInterruptedError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(reasoning.length).toBeGreaterThan(0)
+  })
+
+  it('fails over normally when a stream drops before the first delta', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(preEmitErrorResponse())
+      .mockResolvedValueOnce(streamResponse(['recovered']))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    const deltas: string[] = []
+    const result = await gateway.stream([{ role: 'user', content: 'hi' }], { onText: (chunk) => deltas.push(chunk) })
+    // Nothing reached the client before the drop, so failover is safe and the secondary serves.
+    expect(result.provider).toBe('secondary')
+    expect(deltas.join('')).toBe('recovered')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/tests/typescript/unit/api/operator-orchestrator.test.ts
+++ b/tests/typescript/unit/api/operator-orchestrator.test.ts
@@ -11,7 +11,12 @@ import {
   type SkillRegistry,
   type Skill,
 } from '../../../../apps/api/src/operator-orchestrator.js'
-import type { Gateway, CompletionResult, CompletionObjectResult } from '../../../../apps/api/src/operator-gateway.js'
+import {
+  GatewayStreamInterruptedError,
+  type Gateway,
+  type CompletionResult,
+  type CompletionObjectResult,
+} from '../../../../apps/api/src/operator-gateway.js'
 
 const emptyContext = { facts: null, state: null }
 
@@ -187,6 +192,24 @@ describe('createOrchestrator', () => {
     })
     expect(result.outcome.kind).toBe('answer')
     expect(thinking.join('')).toBe('weighing options')
+  })
+
+  it('propagates a mid-stream interruption instead of swallowing it into an answer', async () => {
+    const completeObject = vi.fn().mockResolvedValue({ value: { tier: 'read', topic: 'general' }, provider: 't', model: 'm' })
+    // The answer stream emits a delta, then the provider drops after output has begun. The gateway
+    // surfaces this as a non-failover interruption; the orchestrator must let it reach the caller so
+    // the route can end the turn rather than returning a truncated answer.
+    const stream = vi.fn(async (_messages: unknown, handlers: { onText: (chunk: string) => void }) => {
+      handlers.onText('the partial ')
+      throw new GatewayStreamInterruptedError('primary', 'connection reset')
+    })
+    const gateway = { status: () => ({ enabled: true, providers: [] }), completeObject, stream } as unknown as Gateway
+    const deltas: string[] = []
+    const error = await createOrchestrator()
+      .handle(gateway, 'why denied', emptyContext, { onAnswerDelta: (chunk) => deltas.push(chunk) })
+      .catch((e) => e)
+    expect(error).toBeInstanceOf(GatewayStreamInterruptedError)
+    expect(deltas).toEqual(['the partial '])
   })
 
   it('plans a change tier with the plan skill', async () => {

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -2583,6 +2583,63 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     expect(terminal.data).toMatchObject({ error: 'ai_budget_exceeded', max_calls: 1, status: 429 })
   })
 
+  it('ends the stream with an interruption frame when a provider drops after streaming, never failing over', async () => {
+    const secondary = { ...provider, id: 'secondary', baseUrl: 'https://api.secondary.example/v1' }
+    // Call 1 is triage, call 2 is the answer stream that delivers a word and then the connection
+    // drops. A call 3 would mean the gateway failed over after streaming - the corruption this
+    // guards against - so its absence is asserted below.
+    let call = 0
+    const fetchImpl = vi.fn(async () => {
+      call += 1
+      if (call === 1) {
+        return new Response(JSON.stringify({ choices: [{ message: { content: '{"tier":"conversational","topic":"general"}' } }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (call === 2) {
+        const enc = new TextEncoder()
+        const frame = `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: 'Hello world ' }, finish_reason: null }] })}\n\n`
+        const stream = new ReadableStream<Uint8Array>({
+          async start(controller) {
+            controller.enqueue(enc.encode(frame))
+            await new Promise((resolve) => setTimeout(resolve, 40))
+            controller.error(new Error('connection reset'))
+          },
+        })
+        return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+      }
+      return new Response(JSON.stringify({ choices: [{ message: { content: 'failover answer' } }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+    const { app, clientQuery } = buildApp(true, { aiProviders: [provider, secondary], fetchImpl })
+    clientQuery
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ rows: [{ status: 'active', mode: 'agent', autopilot: false, next_seq: 1 }] })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 'turn-1', seq: 1, kind: 'message' }] })
+      .mockResolvedValueOnce(undefined)
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/message',
+      payload: { message: 'why was that denied' },
+      headers: { accept: 'text/event-stream' },
+    })
+    expect(res.statusCode).toBe(200)
+    const frames = parseSse(res.body)
+    // The partial answer reached the client before the drop.
+    expect(frames.some((f) => f.event === 'token')).toBe(true)
+    // The turn ends in an interruption frame, not a second provider's answer.
+    const terminal = frames.at(-1)!
+    expect(terminal.event).toBe('error')
+    expect(terminal.data).toMatchObject({ error: 'ai_stream_interrupted', status: 502 })
+    // Triage and the one answer attempt were the only model calls: the secondary was never tried.
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(2)
+  })
+
   it('auto-approves a low-risk plan in agent mode when autopilot is engaged and the master switch is on', async () => {
     // With the master switch on, the conversation engaged, and the zone able to apply - governed
     // identity plus the zone grant - Caracal auto-satisfies the approval for any non-empty plan.


### PR DESCRIPTION
## PR Title

fix: stop mid-stream failover from corrupting the Operator answer stream

## Summary

When an LLM provider streamed some tokens and then failed, the gateway failed over to the next provider, which emitted its own full answer to the same `onText`/`onReasoning` handlers, so the console rendered provider A's truncated fragment immediately followed by provider B's complete answer with no reset. `callProviderStream` now tracks whether any delta has reached the client; a failure after the first delta raises a non-failover `GatewayStreamInterruptedError` that `runWithFailover` re-raises, and the message route ends the turn with a terminal `ai_stream_interrupted` SSE error frame instead of restarting on another provider.

## Related Issue

Fixes #344

## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [ ] Local run
- [x] Unit tests
- [ ] Integration tests

Notes:

Root cause confirmed empirically first: a streamed response that delivers `"Hello world "` and then tears mid-stream calls `onText` with `["Hello ", "world ", ...]` and *then* fails over — the exact corruption path. The behavior after the fix:

- **Post-emit failure fails the turn, never fails over** — after a text *or* reasoning delta reaches the client, a subsequent provider error raises `GatewayStreamInterruptedError`; the next provider is never called (asserted via call count with two providers configured).
- **Pre-emit failure still fails over cleanly** — a stream that drops before any delta behaves exactly as before and the secondary serves.
- **Empty stream** still fails over (existing behavior preserved).
- **Propagation** — an orchestrator test proves the interruption travels through the answer skill to the caller rather than being swallowed into a truncated `{ ok: false }` answer.
- **Route** — a full streaming message turn asserts a `token` frame reaches the client, then a terminal `error` frame carrying `ai_stream_interrupted` (status 502), with exactly two model calls (triage + one answer attempt, no failover).

Full `apps/api` TypeScript suites pass (1285 tests across unit / security / property / contract), `src` typechecks clean, and the repo style check passes.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

The interruption error carries only the provider id (a config label already surfaced in the existing `ai_unreachable` frame), never a key or response body.

## Screenshots / Demos (if UI or UX)

No UI change. The web console already renders any SSE `error` frame generically, so the new `ai_stream_interrupted` code surfaces as a clean stream failure with the partial answer left in place and no second answer appended.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Major new functionality includes automated tests (required)
- [x] Bug fixes include a regression test (required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses that fail after output begins now end clearly with an interruption error instead of silently switching providers.
  * Partial text and reasoning output remains preserved when a stream is interrupted.
  * Streams that fail before producing output can still recover through provider failover.
  * API responses now identify interrupted streams with an appropriate 502 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->