### PR TITLE
test: assert fail-closed denial of unknown provider kinds in the Go STS

### DIFF
--- a/tests/source/go/services/sts/internal/provider_kind_denial_test.go
+++ b/tests/source/go/services/sts/internal/provider_kind_denial_test.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Tests that the STS fails closed on unknown or unsupported provider kinds.
+
+package internal
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// An unknown provider_kind must never resolve to an upstream directive. Every supported kind is
+// named explicitly in applyProviderDirective; anything else - a mis-migrated row, a kind the
+// provider-surface consolidation chose not to add, a wrong case, or a near-miss spelling - must
+// fall through to the fail-closed default so it can neither strip upstream auth nor mint a
+// credential. The provider surface reuses api_key rather than adding an llm_openai kind, so this is
+// the parity guard that keeps that decision enforced at the token boundary.
+func TestBuildUpstreamDirectiveFailsClosedOnUnknownProviderKind(t *testing.T) {
+	upstreamURL := "https://api.pipernet.example"
+	zek := []byte("12345678901234567890123456789012")
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{"kind the consolidation did not add", "llm_openai"},
+		{"unset kind", ""},
+		{"wrong case", "API_KEY"},
+		{"trailing space", "api_key "},
+		{"partial oauth", "oauth2"},
+		{"partial bearer", "bearer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			providerID := "provider1"
+			resource := &Resource{
+				ID:                   "res1",
+				Identifier:           "resource://pipernet",
+				UpstreamURL:          &upstreamURL,
+				CredentialProviderID: &providerID,
+			}
+			srv := providerServer(&stubDB{
+				provider: &ProviderConfig{ID: providerID, ProviderKind: strPtr(tc.kind), ConfigJSON: []byte(`{}`)},
+			}, zek)
+			directive, err := srv.buildUpstreamDirective(context.Background(), "zone1", map[string]any{"sub": "user1"}, resource, true, false)
+			if err == nil || !strings.Contains(err.Error(), "provider kind unsupported") {
+				t.Fatalf("an unknown provider kind must deny with an unsupported-kind error, got directive=%#v err=%v", directive, err)
+			}
+			if directive.AuthMode == UpstreamAuthNone {
+				t.Fatalf("a denied kind must never downgrade upstream auth to none: %#v", directive)
+			}
+			if directive.ProviderToken != "" {
+				t.Fatalf("a denied kind must never mint or attach a provider token: %#v", directive)
+			}
+		})
+	}
+}
+
+// applyProviderDirective is the single point that maps a provider kind onto the upstream auth
+// directive. Its default branch is the fail-closed guarantee: an unrecognized kind returns an error
+// and leaves the directive's auth mode untouched rather than shaping it into an authorized request.
+func TestApplyProviderDirectiveDeniesUnknownProviderKind(t *testing.T) {
+	provider := &ProviderConfig{ID: "provider1", ProviderKind: strPtr("llm_openai"), ConfigJSON: []byte(`{}`)}
+	cfg, err := providerDirectiveConfig(provider.ConfigJSON)
+	if err != nil {
+		t.Fatalf("provider config: %v", err)
+	}
+	directive := UpstreamDirective{AuthMode: UpstreamAuthCaracalJWT, AuthHeader: "Authorization", AuthScheme: "Bearer"}
+	if err := applyProviderDirective(provider, &directive, cfg); err == nil || !strings.Contains(err.Error(), "provider kind unsupported") {
+		t.Fatalf("an unknown provider kind must be denied, got %v", err)
+	}
+	if directive.AuthMode != UpstreamAuthCaracalJWT {
+		t.Fatalf("a denied kind must not rewrite the auth mode: %#v", directive)
+	}
+}


### PR DESCRIPTION
## PR Title

test: assert fail-closed denial of unknown provider kinds in the Go STS

## Summary

Adds the regression test #342 was re-scoped to. `applyProviderDirective` and `providerServiceToken` in the Go STS already handle every supported provider kind and fall through to a `provider kind unsupported` deny on anything else, so this is a test-only change with no runtime behavior. It pins the fail-closed guarantee so a future edit that drops the `default` branch — or the decision to reuse `api_key` instead of adding an `llm_openai` kind — cannot silently regress into an authorized upstream request.

## Related Issue

Closes #342

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [x] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [ ] Local run
- [x] Unit tests
- [ ] Integration tests

Notes:

Two additive tests in `services/sts/internal` (staged from `tests/source/go/...`):

- `TestBuildUpstreamDirectiveFailsClosedOnUnknownProviderKind` — table-driven over an invalid `provider_kind` flowing through `buildUpstreamDirective`: a kind the consolidation chose not to add (`llm_openai`), an unset kind, a wrong-case variant (`API_KEY`), a trailing-space near-miss (`api_key `), and truncated spellings (`oauth2`, `bearer`). Each must deny with the unsupported-kind error and must never downgrade upstream auth to `none` or attach a provider token.
- `TestApplyProviderDirectiveDeniesUnknownProviderKind` — pins the `default` branch of `applyProviderDirective` directly (the exact function named in the issue), so removing it fails the suite even though `providerServiceToken`'s own default would still catch the kind downstream.

Ran locally against the Go 1.26 toolchain the module requires: both tests pass, the full `services/sts/internal` package stays green (`go test`, `go vet`), the file is `gofmt`-clean, and the repo style check passes.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

Test-only; strengthens a security-relevant fail-closed boundary (an unknown provider kind can never resolve to an authorized upstream credential directive).

## Screenshots / Demos (if UI or UX)

N/A.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Major new functionality includes automated tests (required)
- [x] Bug fixes include a regression test (required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added coverage to ensure unsupported or unknown provider types fail safely.
  * Prevented unsupported provider configurations from weakening upstream authentication or issuing provider tokens.
  * Preserved existing authentication settings when invalid provider types are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->