### PR TITLE
refactor: rename the Operator's AI "provider" to "model endpoint"

### DIFF
--- a/apps/web/src/components/console/OperatorComposer.tsx
+++ b/apps/web/src/components/console/OperatorComposer.tsx
@@ -298,7 +298,7 @@ function OperatorModelSelector({
     return (
       <span
         className="inline-flex h-8 flex-shrink-0 cursor-default items-center gap-1.5 rounded-full border border-dashed border-border bg-transparent px-2.5 text-xs text-muted-foreground"
-        title="No AI provider is configured, so the Operator selects automatically. Configure API_OPERATOR_AI_PROVIDERS to choose a model."
+        title="No model endpoint is configured, so the Operator selects automatically. Configure API_OPERATOR_AI_PROVIDERS to choose a model."
       >
         <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />
         Auto

--- a/apps/web/src/components/console/OperatorPolicyDraft.tsx
+++ b/apps/web/src/components/console/OperatorPolicyDraft.tsx
@@ -52,7 +52,7 @@ function deriveDescription(doc: PolicyDocumentView, model: string): string {
 // document, each carrying the exact validated content and a provenance-stamped description. The plan
 // is only proposed here; approval and application stay on the existing gate.
 function buildCreatePlan(draft: PolicyDraftView) {
-  const model = draft.provenance?.model ?? "an AI provider";
+  const model = draft.provenance?.model ?? "a model endpoint";
   const steps = draft.documents.map((doc, index) => ({
     id: `create-${index + 1}`,
     capability: "createPolicy",

--- a/apps/web/src/components/console/OperatorPolicyDraft.tsx
+++ b/apps/web/src/components/console/OperatorPolicyDraft.tsx
@@ -52,7 +52,7 @@ function deriveDescription(doc: PolicyDocumentView, model: string): string {
 // document, each carrying the exact validated content and a provenance-stamped description. The plan
 // is only proposed here; approval and application stay on the existing gate.
 function buildCreatePlan(draft: PolicyDraftView) {
-  const model = draft.provenance?.model ?? "a model endpoint";
+  const model = draft.provenance?.model ?? "an AI model";
   const steps = draft.documents.map((doc, index) => ({
     id: `create-${index + 1}`,
     capability: "createPolicy",

--- a/apps/web/src/platform/nav/settingsNav.ts
+++ b/apps/web/src/platform/nav/settingsNav.ts
@@ -60,7 +60,7 @@ export const SETTINGS_GROUPS: SettingsGroupModel[] = [
       {
         id: "operator",
         label: "AI Operator",
-        description: "Model providers and governed routing for the Caracal Operator.",
+        description: "Model endpoints and governed routing for the Caracal Operator.",
       },
       {
         id: "notifications",

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.ai.{-$conversationNo}.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.ai.{-$conversationNo}.tsx
@@ -263,12 +263,12 @@ const DRAFT_AUTOPILOT_KEY = "caracal.operator.draftAutopilot";
 // clears it too, so an explicit fresh start is honoured rather than bounced back to the prior chat.
 const LAST_CONVERSATION_KEY = "caracal.operator.lastConversation";
 
-// Raised as a warning when a message is sent while no AI provider is connected. The Operator turns
-// natural language into governed plans through a model, so with no provider the send cannot be
+// Raised as a warning when a message is sent while no model endpoint is connected. The Operator turns
+// natural language into governed plans through a model, so with no model endpoint the send cannot be
 // acted on; rather than dispatch it into an upstream refusal, the send is held back and this is
 // surfaced as a non-blocking warning so the operator sees why nothing happened.
 const AI_DISCONNECTED_WARNING =
-  "No AI provider is connected, so the Operator can't act on that. Connect a provider to continue.";
+  "No model endpoint is connected, so the Operator can't act on that. Connect a model endpoint to continue.";
 
 function readRailCollapsed(): boolean {
   if (typeof localStorage === "undefined") return false;
@@ -367,7 +367,7 @@ function OperatorWorkspace() {
   const [streamError, setStreamError] = useState(false);
   // The notice currently surfaced to the operator label, as a discrete event so the same message
   // raised again re-surfaces. Query and stream failures feed it through an effect; a send held back
-  // because no provider is connected reports one directly.
+  // because no model endpoint is connected reports one directly.
   const [operatorNotice, setOperatorNotice] = useState<OperatorNoticeEvent | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const shellRef = useRef<HTMLDivElement>(null);
@@ -526,10 +526,10 @@ function OperatorWorkspace() {
       return "Your sessions could not be loaded. Check your connection and try again.";
     }
     if (create.isError) {
-      return "That session could not be started. Confirm an AI provider is reachable and try again.";
+      return "That session could not be started. Confirm a model endpoint is reachable and try again.";
     }
     if (streamError) {
-      return "That request could not be processed. Confirm an AI provider is reachable and try again.";
+      return "That request could not be processed. Confirm a model endpoint is reachable and try again.";
     }
     return null;
   }, [conversations.isError, create.isError, streamError]);

--- a/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
+++ b/apps/web/src/routes/$accountId.$orgId.$zoneId.app.settings.operator.tsx
@@ -2,7 +2,7 @@
 Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
 Caracal, a product of Garudex Labs
 
-This file defines the Settings AI Operator page for model providers, connectivity, and attribution.
+This file defines the Settings AI Operator page for model endpoints, connectivity, and attribution.
 */
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
@@ -59,7 +59,7 @@ function sanitizeSlug(raw: string): string {
 
 function checkErrorMessage(err: unknown): string {
   if (err instanceof ConsoleApiError) {
-    if (err.code === "ai_unavailable") return "No AI provider is configured for the Operator.";
+    if (err.code === "ai_unavailable") return "No model endpoint is configured for the Operator.";
     if (err.code === "ai_unreachable") {
       // Surface the upstream's own status so a rejected key (401/403) reads differently from a
       // wrong endpoint (404) or an unreachable host, rather than one ambiguous message.
@@ -69,10 +69,10 @@ function checkErrorMessage(err: unknown): string {
       const reason = attempts?.[0]?.reason ?? "";
       const status = reason.match(/status (\d{3})/)?.[1];
       if (status === "401" || status === "403")
-        return "The provider rejected the key. Check the API key.";
+        return "The model endpoint rejected the key. Check the API key.";
       if (status === "404") return "The endpoint was not found. Check the base URL.";
-      if (status) return `The provider returned ${status}. Check the endpoint and key.`;
-      return "The provider could not be reached. Check the endpoint.";
+      if (status) return `The model endpoint returned ${status}. Check the endpoint and key.`;
+      return "The model endpoint could not be reached. Check the endpoint.";
     }
   }
   return "The connectivity check failed. Try again.";
@@ -84,7 +84,7 @@ function writeErrorMessage(err: unknown): string {
       return "Self-governance is not configured, so a key cannot be sealed.";
     if (err.code === "invalid_provider")
       return "Some fields are invalid. Check the form and try again.";
-    if (err.code === "provider_not_found") return "That provider no longer exists.";
+    if (err.code === "provider_not_found") return "That model endpoint no longer exists.";
   }
   return "The change could not be saved. Try again.";
 }
@@ -131,7 +131,7 @@ function OperatorPage() {
     <div>
       <SettingsGroup
         title="Models"
-        description="Add a provider, and Caracal securely routes the Operator to model through the governed gateway."
+        description="Add a model endpoint, and Caracal securely routes the Operator to it through the governed gateway."
         action={
           <>
             <Button
@@ -153,7 +153,7 @@ function OperatorPage() {
                 setFormOpen(true);
               }}
             >
-              Add provider
+              Add model endpoint
             </Button>
           </>
         }
@@ -183,7 +183,7 @@ function OperatorPage() {
             <Skeleton className="h-24 w-full" />
           ) : providers.length === 0 ? (
             <p className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
-              No models yet. Add a provider to bring the Operator online.
+              No models yet. Add a model endpoint to bring the Operator online.
             </p>
           ) : (
             <div className="scrollbar-thin max-h-[420px] divide-y divide-border overflow-y-auto rounded-lg border border-border">
@@ -260,7 +260,10 @@ function OperatorPage() {
         onClose={() => setFormOpen(false)}
         onSaved={() => {
           setFormOpen(false);
-          toast({ tone: "success", title: editing ? "Provider updated" : "Provider added" });
+          toast({
+            tone: "success",
+            title: editing ? "Model endpoint updated" : "Model endpoint added",
+          });
         }}
       />
 
@@ -277,7 +280,7 @@ function OperatorPage() {
 
       <ConfirmModal
         open={deleting !== null}
-        title="Delete provider"
+        title="Delete model endpoint"
         description={
           deleting
             ? `Remove ${deleting.label}? Its sealed key is destroyed and the Operator's grant to it is revoked.`
@@ -290,7 +293,7 @@ function OperatorPage() {
           if (!deleting) return;
           try {
             await remove.mutateAsync(deleting.slug);
-            toast({ tone: "info", title: "Provider deleted" });
+            toast({ tone: "info", title: "Model endpoint deleted" });
           } catch (err) {
             toast({ tone: "error", title: "Delete failed", description: writeErrorMessage(err) });
           }
@@ -604,10 +607,10 @@ function ProviderFormModal({
     <Modal
       open={open}
       onClose={onClose}
-      title={editing ? "Edit provider" : "Add a model provider"}
+      title={editing ? "Edit model endpoint" : "Add a model endpoint"}
       description={
         editing
-          ? "Update the endpoint and models. Rotate the key from the provider's menu."
+          ? "Update the endpoint and models. Rotate the key from its menu."
           : "Supply an OpenAI-compatible endpoint and key; Caracal seals and governs it."
       }
       footer={
@@ -616,7 +619,7 @@ function ProviderFormModal({
             Cancel
           </Button>
           <Button onClick={save} loading={busy} disabled={!valid}>
-            {editing ? "Save changes" : "Add provider"}
+            {editing ? "Save changes" : "Add model endpoint"}
           </Button>
         </>
       }
@@ -630,8 +633,8 @@ function ProviderFormModal({
             placeholder="OpenAI production"
           />
           <Field
-            label="Provider id"
-            info="A short slug Caracal uses to name the sealed provider and resource."
+            label="Endpoint id"
+            info="A short slug Caracal uses to name the sealed credential provider and resource."
             value={slug}
             onChange={(event) => {
               setSlug(sanitizeSlug(event.target.value));
@@ -666,7 +669,7 @@ function ProviderFormModal({
         <div className="grid gap-2">
           <FieldLabel
             label="Models"
-            info="The exact model ids this endpoint serves. One provider can serve several behind the same key."
+            info="The exact model ids this endpoint serves. One model endpoint can serve several behind the same key."
           />
           <div className="flex gap-2">
             <input

--- a/docs/src/content/docs/concepts/operator.mdx
+++ b/docs/src/content/docs/concepts/operator.mdx
@@ -58,15 +58,15 @@ Policy is the densest control-plane object to write by hand: a decision rests on
 
 Every draft is validated and previewed against the same contract the platform enforces, so a document the Operator emits is already contract-valid; if it cannot produce a valid document it fails closed rather than returning broken Rego. A draft is not a change. Turning one into a policy runs the ordinary [governed lifecycle](#the-governed-lifecycle) - you review the proposed create, approve it, and the create is re-validated on apply and attributed to you. Policies authored this way carry provenance marking them AI-assisted, and their later version, simulation, and activation steps stay under the same review and audit as any other policy work.
 
-## Natural-Language Provider
+## Natural-Language Model Endpoint
 
-Turning words into a plan requires a model endpoint supplied by the operator. Open **Settings → AI Operator → Models** to add an OpenAI chat-completions-compatible endpoint, model IDs, optional context window, and key placement. The API key is accepted only when the provider is created or rotated, sealed into a credential Provider in the reserved `caracal.sys` Zone, and never returned to the browser. Operator model calls use the governed Gateway route for that Resource.
+Turning words into a plan requires a model endpoint supplied by the operator. Open **Settings → AI Operator → Models** to add an OpenAI chat-completions-compatible endpoint, model IDs, optional context window, and key placement. The API key is accepted only when the model endpoint is created or rotated, sealed into a credential Provider in the reserved `caracal.sys` Zone, and never returned to the browser. Operator model calls use the governed Gateway route for that Resource.
 
-The settings page can edit provider metadata, rotate the sealed key, delete a provider, and run a real connectivity check. Multiple providers and models participate in failover. Direct API-process `API_OPERATOR_AI_*` configuration also remains implemented, but the packaged-runtime workflow is console management; see [Configure Service Environment](/operations/env-vars/#api-operator-and-control) for that narrower path.
+The settings page can edit model endpoint metadata, rotate the sealed key, delete a model endpoint, and run a real connectivity check. Multiple model endpoints and models participate in failover. Direct API-process `API_OPERATOR_AI_*` configuration also remains implemented, but the packaged-runtime workflow is console management; see [Configure Service Environment](/operations/env-vars/#api-operator-and-control) for that narrower path.
 
 ## Where to Use It
 
-Open **Caracal Operator** from the console utility rail or command palette. For the workspace and provider-management paths, see [Caracal Operator](/runtime-console/console/#caracal-operator) in the web console reference.
+Open **Caracal Operator** from the console utility rail or command palette. For the workspace and model-endpoint management paths, see [Caracal Operator](/runtime-console/console/#caracal-operator) in the web console reference.
 
 ## Common Mistakes
 

--- a/docs/src/content/docs/operations/env-vars.mdx
+++ b/docs/src/content/docs/operations/env-vars.mdx
@@ -73,7 +73,7 @@ The packaged Compose stack wires `CARACAL_TLS_EXTRA_CA_FILE` for you: drop a PEM
 | `API_OPERATOR_AI_MAX_CALLS_PER_TURN` | Per-turn model-call budget. |
 | `CARACAL_CONTROL_ENABLED`, `CONTROL_GATE_FILE` | Build-time Control mount and runtime invoke gate. |
 
-The API process also accepts `API_OPERATOR_AI_PROVIDERS` plus per-ID `API_OPERATOR_AI_<ID>_BASE_URL`, `_MODEL`, optional `_API_KEY`, `_TIMEOUT_MS`, and `_CONTEXT_WINDOW`. IDs are tried in listed order before console-managed providers. Those variables are a direct API-process configuration path; the installed-runtime Compose and Helm surfaces do not forward provider-specific entries. For the packaged workflow, configure providers under **Settings → AI Operator → Models**, where keys are sealed into `caracal.sys` and never returned.
+The API process also accepts `API_OPERATOR_AI_PROVIDERS` plus per-ID `API_OPERATOR_AI_<ID>_BASE_URL`, `_MODEL`, optional `_API_KEY`, `_TIMEOUT_MS`, and `_CONTEXT_WINDOW`. IDs are tried in listed order before console-managed model endpoints. Those variables are a direct API-process configuration path; the installed-runtime Compose and Helm surfaces do not forward model-endpoint-specific entries. For the packaged workflow, configure model endpoints under **Settings → AI Operator → Models**, where keys are sealed into `caracal.sys` and never returned.
 
 ## Safe Procedure
 

--- a/docs/src/content/docs/runtime-console/console.mdx
+++ b/docs/src/content/docs/runtime-console/console.mdx
@@ -66,7 +66,7 @@ Provider secrets are entered during supported create or rotation flows and remai
 
 Open **Caracal Operator** from the utility rail or command palette. Each conversation runs in **Ask** mode for read-only investigation or **Agent** mode for answers, live reads, and change plans. A mutating plan is validated and previewed against current state, then waits for Approval before it is revalidated and applied. Conversation memory records activity; live reads and execution previews remain the source of truth for current state.
 
-Configure natural-language models under **Settings → AI Operator → Models**. The page can add, edit, test, rotate, and delete OpenAI-compatible providers. A new or rotated key is sent once, sealed into the reserved `caracal.sys` Zone, and never returned. Caracal routes model calls through the governed Gateway. The Operator can still expose deterministic catalog and plan behavior when no model provider is configured, but natural-language assistance remains unavailable.
+Configure natural-language models under **Settings → AI Operator → Models**. The page can add, edit, test, rotate, and delete OpenAI-compatible model endpoints. A new or rotated key is sent once, sealed into the reserved `caracal.sys` Zone, and never returned. Caracal routes model calls through the governed Gateway. The Operator can still expose deterministic catalog and plan behavior when no model endpoint is configured, but natural-language assistance remains unavailable.
 
 ## Next Step
 


### PR DESCRIPTION
## PR Title

refactor: rename the Operator's AI "provider" to "model endpoint"

## Summary

Per the terminology re-scope on #335, this disambiguates the one overloaded meaning of "provider" that caused confusion: the Operator's own AI model backend (an OpenAI-compatible base URL + key + model IDs). It is renamed to **model endpoint** in user-facing copy and the current docs, so "provider" is left to mean the **credential Provider** alone. Provider Connections, social/login providers, code identifiers, API fields, and the locked v0.2 docs snapshot are intentionally untouched.

## Related Issue

Closes #335

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [ ] Local run
- [x] Unit tests
- [ ] Integration tests

Notes:

Renamed **only** the AI-model-endpoint sense of "provider":

- **Console copy** — AI Operator settings (panel description, `Add model endpoint`, empty state, `Edit`/`Add`/`Delete model endpoint` modals and toasts, `Endpoint id` field, help text, connectivity error messages), the conversation surface's disconnected/error notices, the model-selector tooltip, the policy-draft provenance fallback, and the settings-nav description.
- **Docs (current, non-versioned)** — `concepts/operator.mdx`, `runtime-console/console.mdx`, `operations/env-vars.mdx`.

Deliberately **not** changed:
- The panel/nav title **Models** and the `Settings → AI Operator → Models` path (not ambiguous; keeps existing doc references valid).
- Where a model endpoint's key seals into a **credential Provider**, that reference is qualified as "credential provider" rather than renamed.
- **Credential Providers**, **Provider Connections**, **social sign-in providers** — all left as "provider".
- Code identifiers (`OperatorAiProvider`, `useOperatorAiProviders`, the `ProviderFormModal` component, the `providers` field), API routes, error codes (`ai_unavailable`, `provider_not_found`), and the `API_OPERATOR_AI_PROVIDERS` env var name.
- The **immutable `v0.2` docs snapshot** (verified untouched; edits follow the repo convention of editing the non-versioned "next" docs only, matching prior terminology passes).

Verification (Node 24 / TS toolchain the repo requires): web `tsc --noEmit` clean, web unit tests 391 passed, docs unit tests (links + versioning) 17 passed, `docsVersion.mjs verify` passed, and the repo style/Prettier gate passes. A final residual grep confirms no user-facing AI-model "provider" remains and that only credential/social/connection "provider" mentions are left in place.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

Copy/documentation only — no behavior, API, or wire change.

## Screenshots / Demos (if UI or UX)

Text-only relabeling of the AI Operator settings and conversation surfaces; no layout or flow changes.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Major new functionality includes automated tests (required)
- [ ] Bug fixes include a regression test (required)

Terminology/copy change with no behavior change, so no new tests; existing web and docs suites cover the affected surfaces and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized AI Operator terminology across the console from “AI provider” to “model endpoint,” including fallback/tooltips and workspace connectivity messaging.
  * Updated connectivity guidance for session/request failures to instruct confirming a reachable model endpoint.
  * Refreshed model management UI text (labels, actions, modals, toasts, confirmations, and empty states) and aligned policy draft wording to “AI model.”

* **Documentation**
  * Revised concepts and operational docs to use “Natural-Language Model Endpoint” and updated env-var guidance under model-endpoint terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->