### PR TITLE
fix: enable bounded Operator provider retries

### DIFF
--- a/apps/api/src/operator-gateway.ts
+++ b/apps/api/src/operator-gateway.ts
@@ -17,6 +17,11 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import type { ZodType } from 'zod'
 import { buildGovernanceMiddleware, type GovernanceLimits } from './operator-ai-governance.js'
 
+// Let the AI SDK absorb one transient failure on the current provider before the gateway moves
+// through its failover order. The SDK owns retry classification, exponential backoff, and
+// Retry-After handling; the provider timeout still bounds the entire attempt including this retry.
+const PROVIDER_MAX_RETRIES = 1
+
 // A single configured backend. The OpenAI-compatible chat surface is the common
 // denominator across hosted providers (OpenAI, Together, Groq), local servers
 // (Ollama, vLLM), and aggregators (OpenRouter), so one client reaches all of them
@@ -325,10 +330,9 @@ function failureReason(err: unknown): string {
   return 'unknown error'
 }
 
-// Performs one free-text chat completion against a single provider through the AI SDK.
-// Per-call retry is disabled so this gateway's own failover order owns retry semantics;
-// network failures, non-2xx responses, timeouts, and empty completions all throw so the
-// caller can fail over.
+// Performs one free-text chat completion against a single provider through the AI SDK. One
+// SDK-managed retry absorbs a retryable transient failure before network failures, non-2xx
+// responses, timeouts, and empty completions throw so the caller can fail over.
 async function callProvider(
   fetchImpl: FetchImpl,
   provider: ProviderConfig,
@@ -347,7 +351,7 @@ async function callProvider(
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
       abortSignal: controller.signal,
-      maxRetries: 0,
+      maxRetries: PROVIDER_MAX_RETRIES,
     })
     const text = result.text.trim()
     if (text.length === 0) throw new Error('provider returned an empty completion')
@@ -368,7 +372,7 @@ async function callProvider(
 // Performs one streaming free-text chat completion against a single provider. It emits each text
 // and reasoning delta to the handlers as it arrives, then returns the same CompletionResult the
 // non-streaming path would, so a caller gets a live preview and the authoritative final text from
-// one call. Per-call retry is disabled so this gateway's own failover order owns retry semantics. A
+// one call. One SDK-managed retry absorbs a retryable failure while the stream is being opened. A
 // provider that fails before the first delta fails over cleanly like the non-streaming path; a
 // provider that fails after a delta has reached the client cannot fail over without appending a
 // second answer to the partial one already on screen, so it raises a GatewayStreamInterruptedError
@@ -396,7 +400,7 @@ async function callProviderStream(
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
       abortSignal: controller.signal,
-      maxRetries: 0,
+      maxRetries: PROVIDER_MAX_RETRIES,
       // Azure delivers a completion in a few coarse chunks, so every token of a chunk lands in one
       // burst and a short answer arrives all at once. Re-pace the text channel word by word so the
       // answer types out smoothly for the reader while reasoning parts pass through untouched.
@@ -467,7 +471,7 @@ async function callProviderObject<T>(
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
       abortSignal: controller.signal,
-      maxRetries: 0,
+      maxRetries: PROVIDER_MAX_RETRIES,
     })
     return {
       value: result.object,

--- a/docs/src/content/docs/concepts/operator.mdx
+++ b/docs/src/content/docs/concepts/operator.mdx
@@ -62,7 +62,7 @@ Every draft is validated and previewed against the same contract the platform en
 
 Turning words into a plan requires a model endpoint supplied by the operator. Open **Settings → AI Operator → Models** to add an OpenAI chat-completions-compatible endpoint, model IDs, optional context window, and key placement. The API key is accepted only when the model endpoint is created or rotated, sealed into a credential Provider in the reserved `caracal.sys` Zone, and never returned to the browser. Operator model calls use the governed Gateway route for that Resource.
 
-The settings page can edit model endpoint metadata, rotate the sealed key, delete a model endpoint, and run a real connectivity check. Multiple model endpoints and models participate in failover. Direct API-process `API_OPERATOR_AI_*` configuration also remains implemented, but the packaged-runtime workflow is console management; see [Configure Service Environment](/operations/env-vars/#api-operator-and-control) for that narrower path.
+The settings page can edit model endpoint metadata, rotate the sealed key, delete a model endpoint, and run a real connectivity check. Multiple model endpoints and models participate in failover. Each logical completion gives its current model endpoint one SDK-managed retry for transient failures, including rate limits and server errors; terminal failures move directly to the next endpoint, and the endpoint timeout bounds the retry as well as the initial request. Direct API-process `API_OPERATOR_AI_*` configuration also remains implemented, but the packaged-runtime workflow is console management; see [Configure Service Environment](/operations/env-vars/#api-operator-and-control) for that narrower path.
 
 ## Where to Use It
 

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -162,16 +162,25 @@ describe('gateway complete', () => {
   })
 
   it('honors Retry-After before retrying the same provider', async () => {
-    const callsAt: number[] = []
-    const fetchMock = vi.fn(async () => {
-      callsAt.push(Date.now())
-      return callsAt.length === 1 ? errorResponse(429, { 'retry-after': '0.03' }) : chatResponse('OK')
-    })
-    const gateway = createGateway([provider({ id: 'primary' })], fetchMock as unknown as typeof fetch)
-    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
-    expect(result.provider).toBe('primary')
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(callsAt[1]! - callsAt[0]!).toBeGreaterThanOrEqual(20)
+    vi.useFakeTimers()
+    try {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(errorResponse(429, { 'retry-after': '0.03' }))
+        .mockResolvedValueOnce(chatResponse('OK'))
+      const gateway = createGateway([provider({ id: 'primary' })], fetchMock as unknown as typeof fetch)
+      const completion = gateway.complete([{ role: 'user', content: 'ping' }])
+
+      await vi.advanceTimersByTimeAsync(29)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      const result = await completion
+      expect(result.provider).toBe('primary')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('retries a recognized network error on the same provider', async () => {

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -28,6 +28,13 @@ function chatResponse(content: string, usage?: { prompt_tokens: number; completi
   })
 }
 
+function errorResponse(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify({ error: { message: `provider returned ${status}` } }), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  })
+}
+
 // Builds an OpenAI-compatible streaming response: one chat.completion.chunk per content delta,
 // a terminal stop chunk carrying usage, then the [DONE] sentinel, so streamText parses the same
 // shape a real provider sends.
@@ -116,26 +123,71 @@ describe('gateway complete', () => {
     expect((init.headers as Record<string, string>).authorization).toBeUndefined()
   })
 
-  it('fails over to the next provider on a 5xx response', async () => {
+  it('retries a rate limit on the same provider and succeeds without failover', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(errorResponse(429, { 'retry-after-ms': '0' }))
+      .mockResolvedValueOnce(chatResponse('OK'))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
+    expect(result.provider).toBe('primary')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails over after the current provider exhausts its single retry', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(503, { 'retry-after-ms': '0' }))
+      .mockResolvedValueOnce(errorResponse(503, { 'retry-after-ms': '0' }))
       .mockResolvedValueOnce(chatResponse('OK'))
     const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
     const result = await gateway.complete([{ role: 'user', content: 'ping' }])
     expect(result.provider).toBe('secondary')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips directly to the next provider on a terminal 400 response', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(errorResponse(400)).mockResolvedValueOnce(chatResponse('OK'))
+    const gateway = createGateway(
+      [provider({ id: 'primary' }), provider({ id: 'secondary', baseUrl: 'https://secondary.example.com/v1' })],
+      fetchMock as unknown as typeof fetch,
+    )
+    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
+    expect(result.provider).toBe('secondary')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      'https://api.example.com/v1/chat/completions',
+      'https://secondary.example.com/v1/chat/completions',
+    ])
+  })
+
+  it('honors Retry-After before retrying the same provider', async () => {
+    const callsAt: number[] = []
+    const fetchMock = vi.fn(async () => {
+      callsAt.push(Date.now())
+      return callsAt.length === 1 ? errorResponse(429, { 'retry-after': '0.03' }) : chatResponse('OK')
+    })
+    const gateway = createGateway([provider({ id: 'primary' })], fetchMock as unknown as typeof fetch)
+    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
+    expect(result.provider).toBe('primary')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(callsAt[1]! - callsAt[0]!).toBeGreaterThanOrEqual(20)
+  })
+
+  it('retries a recognized network error on the same provider', async () => {
+    const networkError = Object.assign(new TypeError('fetch failed'), { cause: new Error('ECONNRESET') })
+    const fetchMock = vi.fn().mockRejectedValueOnce(networkError).mockResolvedValueOnce(chatResponse('OK'))
+    const gateway = createGateway(
+      [provider({ id: 'primary', timeoutMs: 5000 }), provider({ id: 'secondary' })],
+      fetchMock as unknown as typeof fetch,
+    )
+    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
+    expect(result.provider).toBe('primary')
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it('fails over on a network error', async () => {
-    const fetchMock = vi.fn().mockRejectedValueOnce(new TypeError('connection refused')).mockResolvedValueOnce(chatResponse('OK'))
-    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
-    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
-    expect(result.provider).toBe('secondary')
-  })
-
   it('throws GatewayError listing redacted attempts when every provider fails', async () => {
-    const fetchMock = vi.fn(async () => new Response('boom', { status: 500 }))
+    const fetchMock = vi.fn(async () => errorResponse(500, { 'retry-after-ms': '0' }))
     const gateway = createGateway(
       [provider({ id: 'primary', apiKey: 'sk-secret' }), provider({ id: 'secondary', apiKey: 'sk-other' })],
       fetchMock as unknown as typeof fetch,
@@ -145,6 +197,7 @@ describe('gateway complete', () => {
     expect(error.attempts).toHaveLength(2)
     expect(error.attempts.map((a: { provider: string }) => a.provider)).toEqual(['primary', 'secondary'])
     expect(JSON.stringify(error.attempts)).not.toContain('sk-')
+    expect(fetchMock).toHaveBeenCalledTimes(4)
   })
 
   it('treats an empty completion as a failure and fails over', async () => {
@@ -167,6 +220,19 @@ describe('gateway complete', () => {
     const gateway = createGateway([provider({ id: 'slow', timeoutMs: 10 }), provider({ id: 'fast' })], fetchMock as unknown as typeof fetch)
     const result = await gateway.complete([{ role: 'user', content: 'ping' }])
     expect(result.provider).toBe('fast')
+  })
+
+  it('bounds retry backoff with the provider timeout before failing over', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(429, { 'retry-after-ms': '1000' }))
+      .mockResolvedValueOnce(chatResponse('OK'))
+    const gateway = createGateway([provider({ id: 'slow', timeoutMs: 10 }), provider({ id: 'fast' })], fetchMock as unknown as typeof fetch)
+    const startedAt = Date.now()
+    const result = await gateway.complete([{ role: 'user', content: 'ping' }])
+    expect(result.provider).toBe('fast')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(Date.now() - startedAt).toBeLessThan(500)
   })
 })
 
@@ -354,6 +420,17 @@ describe('gateway completeObject', () => {
     expect(result).toMatchObject({ value: validPlan, provider: 'p1', model: 'gpt-x', promptTokens: 6, completionTokens: 2 })
   })
 
+  it('retries a transient structured-completion failure on the same provider', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(503, { 'retry-after-ms': '0' }))
+      .mockResolvedValueOnce(objectResponse(validPlan))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    const result = await gateway.completeObject([{ role: 'user', content: 'connect github' }], ProposedPlan)
+    expect(result).toMatchObject({ value: validPlan, provider: 'primary' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('throws GatewayUnavailableError when nothing is configured', async () => {
     const gateway = createGateway([])
     await expect(gateway.completeObject([{ role: 'user', content: 'hi' }], ProposedPlan)).rejects.toBeInstanceOf(GatewayUnavailableError)
@@ -401,6 +478,19 @@ describe('gateway stream', () => {
     const result = await gateway.stream([{ role: 'user', content: 'hi' }], { onText: (chunk) => deltas.push(chunk) })
     expect(deltas.join('')).toBe('Hello')
     expect(result).toMatchObject({ text: 'Hello', provider: 'p1', model: 'gpt-x', promptTokens: 3, completionTokens: 2 })
+  })
+
+  it('retries a transient failure while opening a stream on the same provider', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(429, { 'retry-after-ms': '0' }))
+      .mockResolvedValueOnce(streamResponse(['recovered']))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    const deltas: string[] = []
+    const result = await gateway.stream([{ role: 'user', content: 'hi' }], { onText: (chunk) => deltas.push(chunk) })
+    expect(result.provider).toBe('primary')
+    expect(deltas.join('')).toBe('recovered')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('streams reasoning deltas to onReasoning and keeps the answer clean', async () => {
@@ -560,6 +650,19 @@ describe('withUsage', () => {
     await gateway.complete([{ role: 'user', content: 'b' }])
     // The third call is refused before reaching a provider, so only two requests were made.
     await expect(gateway.complete([{ role: 'user', content: 'c' }])).rejects.toBeInstanceOf(GatewayBudgetError)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps an SDK retry inside one logical model-call budget entry', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(429, { 'retry-after-ms': '0' }))
+      .mockResolvedValueOnce(chatResponse('OK'))
+    const base = createGateway([provider()], fetchMock as unknown as typeof fetch)
+    const { gateway } = withUsage(base, { maxCalls: 1 })
+    const result = await gateway.complete([{ role: 'user', content: 'a' }])
+    expect(result.text).toBe('OK')
+    await expect(gateway.complete([{ role: 'user', content: 'b' }])).rejects.toBeInstanceOf(GatewayBudgetError)
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 


### PR DESCRIPTION
## Summary

Enables one AI SDK-managed retry for retryable Operator provider failures across text, streaming, and structured completions before the gateway moves through its existing failover order. This uses the SDK's built-in error classification, exponential backoff, and Retry-After handling while retaining the existing provider timeout and per-turn logical-call budget as outer bounds.

Adds regression coverage for same-provider recovery, retry exhaustion, terminal 400 failover, Retry-After timing, transport failures, timeout-bounded backoff, streaming and structured completions, and call-budget accounting. The Operator docs now describe the bounded retry behavior.

## Related Issue

Fixes #345

## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [ ] Local run
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested (explain why)

Notes:

- Focused gateway suite: 58/58 passing, repeated 10 consecutive times (580/580 executions).
- Complete API matrix: 77 files and 1,354 tests passing.
- Repository TypeScript matrix: all 18 package suites passing, plus style, builds, lint, and typecheck.
- Documentation build: 325 pages passing.
- Python matrix: 504/504 passing in an isolated environment. The repository's current hashed test lock omits `typing_extensions`, so the same pinned top-level dependencies plus that transitive dependency were used locally.
- The Go matrix could not run locally because this machine has no Go executable; hosted CI remains the authoritative Go check. No Go code is changed.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

## Screenshots / Demos (if UI or UX)

Not applicable; no UI change.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Major new functionality includes automated tests (required)
- [x] Bug fixes include a regression test (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Provider requests now automatically retry once after transient rate-limit, server, or network failures.
  - Streaming and structured responses receive the same retry handling as standard completions.
  - Terminal failures continue to the next available endpoint.
  - Retry delays use bounded backoff, while configured timeouts apply to both attempts.
  - Retry behavior is applied consistently across supported completion types.

- **Documentation**
  - Updated model endpoint documentation to explain retry behavior and failover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->