### PR TITLE
fix: deprioritize recently failing Operator providers

### DIFF
--- a/apps/api/src/operator-gateway.ts
+++ b/apps/api/src/operator-gateway.ts
@@ -172,6 +172,52 @@ export class GatewayStreamInterruptedError extends Error {
 
 type FetchImpl = typeof fetch
 
+// A failed provider is moved behind providers without a recent failure for one minute. The state
+// is deliberately process-local and advisory: providers remain in the order, so wider outages
+// still reach every configured backend, and the original priority returns automatically. Scoping
+// the memory to the injected transport shares it across per-request gateway rebuilds while keeping
+// independent server/test instances isolated.
+const PROVIDER_FAILURE_DEPRIORITIZATION_MS = 60_000
+const providerFailuresByTransport = new WeakMap<FetchImpl, Map<string, number>>()
+
+function providerFailureKey(provider: ProviderConfig): string {
+  // Include mutable endpoint identity so editing or replacing a provider does not inherit the old
+  // endpoint's failure. Delimiters are encoded by JSON rather than stored ad hoc, and no key or
+  // other credential enters the process-local map.
+  return JSON.stringify([provider.id, provider.baseUrl, provider.model])
+}
+
+function providerFailures(fetchImpl: FetchImpl): Map<string, number> {
+  const existing = providerFailuresByTransport.get(fetchImpl)
+  if (existing) return existing
+  const created = new Map<string, number>()
+  providerFailuresByTransport.set(fetchImpl, created)
+  return created
+}
+
+function providerOrder(
+  available: ProviderConfig[],
+  preferredProvider: string | undefined,
+  failures: Map<string, number>,
+): ProviderConfig[] {
+  const now = Date.now()
+  for (const [key, failedAt] of failures) {
+    if (now - failedAt >= PROVIDER_FAILURE_DEPRIORITIZATION_MS) failures.delete(key)
+  }
+
+  // An explicit per-conversation preference remains a caller override. The remaining providers
+  // retain their configured relative order within the normal and recently-failing groups.
+  const preferred = preferredProvider ? available.find((provider) => provider.id === preferredProvider) : undefined
+  const normal: ProviderConfig[] = []
+  const recentlyFailing: ProviderConfig[] = []
+  for (const provider of available) {
+    if (provider === preferred) continue
+    const group = failures.has(providerFailureKey(provider)) ? recentlyFailing : normal
+    group.push(provider)
+  }
+  return preferred ? [preferred, ...normal, ...recentlyFailing] : [...normal, ...recentlyFailing]
+}
+
 // The OpenAI-compatible provider emits one benign warning on every structured
 // completion that runs against a backend which does not advertise strict schema
 // support: the gateway deliberately uses the portable JSON-object mode and validates
@@ -493,30 +539,28 @@ export interface Gateway {
   stream(messages: GatewayMessage[], handlers: StreamHandlers, options?: CompletionOptions): Promise<CompletionResult>
 }
 
-// Runs a per-provider call through the failover order and returns the first success.
-// The caller's preferred provider, when available, is tried ahead of the rest; a
-// preference for an unknown or unavailable provider is ignored so a stale preference
-// never disables the gateway. Every provider failing throws a GatewayError carrying the
-// redacted per-provider reasons.
+// Runs a per-provider call through the failover order and returns the first success. A provider
+// that failed recently moves behind providers without a recent failure, but is never skipped. The
+// caller's preferred provider, when available, is still tried first; a preference for an unknown
+// or unavailable provider is ignored so a stale preference never disables the gateway. Every
+// provider failing throws a GatewayError carrying the redacted per-provider reasons.
 async function runWithFailover<T>(
   available: ProviderConfig[],
   preferredProvider: string | undefined,
+  failures: Map<string, number>,
   call: (provider: ProviderConfig) => Promise<T>,
 ): Promise<T> {
   if (available.length === 0) throw new GatewayUnavailableError()
-  const order = [...available]
-  if (preferredProvider) {
-    const index = order.findIndex((provider) => provider.id === preferredProvider)
-    if (index > 0) {
-      const [preferred] = order.splice(index, 1)
-      order.unshift(preferred)
-    }
-  }
+  const order = providerOrder(available, preferredProvider, failures)
   const attempts: { provider: string; reason: string }[] = []
   for (const provider of order) {
+    const failureKey = providerFailureKey(provider)
     try {
-      return await call(provider)
+      const result = await call(provider)
+      failures.delete(failureKey)
+      return result
     } catch (err) {
+      failures.set(failureKey, Date.now())
       // A stream that already reached the client cannot be retried on another provider without
       // corrupting the visible output, so this failure ends the turn instead of failing over.
       if (err instanceof GatewayStreamInterruptedError) throw err
@@ -533,6 +577,7 @@ async function runWithFailover<T>(
 // Caracal governance middleware so the ceiling holds uniformly across providers.
 export function createGateway(providers: ProviderConfig[], fetchImpl: FetchImpl = fetch, governance?: GovernanceLimits): Gateway {
   const available = providers.filter(providerAvailable)
+  const failures = providerFailures(fetchImpl)
   const governanceMiddleware = governance && governance.maxOutputTokens > 0 ? buildGovernanceMiddleware(governance) : undefined
 
   return {
@@ -549,24 +594,24 @@ export function createGateway(providers: ProviderConfig[], fetchImpl: FetchImpl 
     },
 
     active() {
-      const provider = available[0]
+      const provider = providerOrder(available, undefined, failures)[0]
       return provider ? { model: provider.model, contextWindow: provider.contextWindow } : null
     },
 
     complete(messages, options = {}) {
-      return runWithFailover(available, options.preferredProvider, (provider) =>
+      return runWithFailover(available, options.preferredProvider, failures, (provider) =>
         callProvider(fetchImpl, provider, messages, options, governanceMiddleware),
       )
     },
 
     completeObject(messages, schema, options = {}) {
-      return runWithFailover(available, options.preferredProvider, (provider) =>
+      return runWithFailover(available, options.preferredProvider, failures, (provider) =>
         callProviderObject(fetchImpl, provider, messages, schema, options, governanceMiddleware),
       )
     },
 
     stream(messages, handlers, options = {}) {
-      return runWithFailover(available, options.preferredProvider, (provider) =>
+      return runWithFailover(available, options.preferredProvider, failures, (provider) =>
         callProviderStream(fetchImpl, provider, messages, options, handlers, governanceMiddleware),
       )
     },

--- a/apps/api/src/operator-gateway.ts
+++ b/apps/api/src/operator-gateway.ts
@@ -182,9 +182,19 @@ const providerFailuresByTransport = new WeakMap<FetchImpl, Map<string, number>>(
 
 function providerFailureKey(provider: ProviderConfig): string {
   // Include mutable endpoint identity so editing or replacing a provider does not inherit the old
-  // endpoint's failure. Delimiters are encoded by JSON rather than stored ad hoc, and no key or
-  // other credential enters the process-local map.
-  return JSON.stringify([provider.id, provider.baseUrl, provider.model])
+  // endpoint's failure. Userinfo, query parameters, and fragments are deliberately excluded so a
+  // credential embedded in a URL never enters the process-local map.
+  let endpointOrigin = 'invalid'
+  let endpointPath = ''
+  try {
+    const endpoint = new URL(provider.baseUrl)
+    endpointOrigin = endpoint.origin
+    endpointPath = endpoint.pathname
+  } catch {
+    // Invalid configured URLs will fail when called; the provider id and model still give them a
+    // stable, non-sensitive failure identity without retaining the malformed input.
+  }
+  return JSON.stringify([provider.id, endpointOrigin, endpointPath, provider.model])
 }
 
 function providerFailures(fetchImpl: FetchImpl): Map<string, number> {

--- a/docs/src/content/docs/concepts/operator.mdx
+++ b/docs/src/content/docs/concepts/operator.mdx
@@ -64,6 +64,8 @@ Turning words into a plan requires a model endpoint supplied by the operator. Op
 
 The settings page can edit model endpoint metadata, rotate the sealed key, delete a model endpoint, and run a real connectivity check. Multiple model endpoints and models participate in failover. Direct API-process `API_OPERATOR_AI_*` configuration also remains implemented, but the packaged-runtime workflow is console management; see [Configure Service Environment](/operations/env-vars/#api-operator-and-control) for that narrower path.
 
+When an endpoint fails, the API process temporarily moves it behind endpoints without a recent failure. It remains available as a fallback, a later success restores it immediately, and its configured priority returns automatically after the recovery window. This ordering memory is local to each API process and resets on restart.
+
 ## Where to Use It
 
 Open **Caracal Operator** from the console utility rail or command palette. For the workspace and model-endpoint management paths, see [Caracal Operator](/runtime-console/console/#caracal-operator) in the web console reference.

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -170,6 +170,120 @@ describe('gateway complete', () => {
   })
 })
 
+describe('gateway recent-failure ordering', () => {
+  const providers = [
+    provider({ id: 'primary', baseUrl: 'https://primary.example.com/v1', model: 'gpt-primary', contextWindow: 128000 }),
+    provider({ id: 'secondary', baseUrl: 'https://secondary.example.com/v1', model: 'gpt-secondary', contextWindow: 64000 }),
+  ]
+
+  it('shares a failure across gateway rebuilds and deprioritizes that provider', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('fallback'))
+    const first = createGateway(providers, fetchMock as unknown as typeof fetch)
+    expect((await first.complete([{ role: 'user', content: 'ping' }])).provider).toBe('secondary')
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('next turn'))
+    const rebuilt = createGateway(providers, fetchMock as unknown as typeof fetch)
+    expect(rebuilt.active()).toEqual({ model: 'gpt-secondary', contextWindow: 64000 })
+    expect((await rebuilt.complete([{ role: 'user', content: 'ping again' }])).provider).toBe('secondary')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://secondary.example.com/v1/chat/completions')
+  })
+
+  it('keeps a recently failing provider as fallback and clears its failure on success', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('fallback'))
+    await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }])
+
+    // Secondary is tried first on the next turn. When it fails, primary is still attempted rather
+    // than skipped; its success clears the remembered failure immediately.
+    fetchMock
+      .mockReset()
+      .mockResolvedValueOnce(new Response('secondary down', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('recovered'))
+    const recovered = await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'second' }])
+    expect(recovered.provider).toBe('primary')
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      'https://secondary.example.com/v1/chat/completions',
+      'https://primary.example.com/v1/chat/completions',
+    ])
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('primary again'))
+    const restored = createGateway(providers, fetchMock as unknown as typeof fetch)
+    expect(restored.active()).toEqual({ model: 'gpt-primary', contextWindow: 128000 })
+    expect((await restored.complete([{ role: 'user', content: 'third' }])).provider).toBe('primary')
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://primary.example.com/v1/chat/completions')
+  })
+
+  it('restores configured priority when the recent-failure window expires', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+      const startedAt = new Date('2026-08-08T00:00:00Z')
+      vi.setSystemTime(startedAt)
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+        .mockResolvedValueOnce(chatResponse('fallback'))
+      await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }])
+
+      vi.setSystemTime(new Date(startedAt.getTime() + 60_001))
+      fetchMock.mockReset().mockResolvedValue(chatResponse('recovered'))
+      const recovered = createGateway(providers, fetchMock as unknown as typeof fetch)
+      expect(recovered.active()).toEqual({ model: 'gpt-primary', contextWindow: 128000 })
+      expect((await recovered.complete([{ role: 'user', content: 'second' }])).provider).toBe('primary')
+      expect(fetchMock.mock.calls[0]![0]).toBe('https://primary.example.com/v1/chat/completions')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps an explicit provider preference ahead of recent-failure ordering', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('fallback'))
+    await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }])
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('preferred recovered'))
+    const result = await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'second' }], {
+      preferredProvider: 'primary',
+    })
+    expect(result.provider).toBe('primary')
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://primary.example.com/v1/chat/completions')
+  })
+
+  it('always attempts a single configured provider even when it failed recently', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response('boom', { status: 503 }))
+    const only = [provider({ id: 'only', baseUrl: 'https://only.example.com/v1' })]
+    await expect(
+      createGateway(only, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }]),
+    ).rejects.toBeInstanceOf(GatewayError)
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('back'))
+    const result = await createGateway(only, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'second' }])
+    expect(result.provider).toBe('only')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not transfer failure memory to an edited endpoint', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('fallback'))
+    await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }])
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('edited endpoint'))
+    const edited = [provider({ ...providers[0], model: 'gpt-primary-v2' }), providers[1]!]
+    const result = await createGateway(edited, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'second' }])
+    expect(result.provider).toBe('primary')
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://primary.example.com/v1/chat/completions')
+  })
+})
+
 describe('gateway wire-parameter adaptation', () => {
   function rejectsParam(param: string, hint: string): Response {
     return new Response(
@@ -443,6 +557,23 @@ describe('gateway stream', () => {
     // answer can never append to the corrupted stream.
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(deltas.length).toBeGreaterThan(0)
+  })
+
+  it('deprioritizes a provider after its stream is interrupted', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(midStreamErrorResponse({ content: 'partial answer ' }))
+      .mockResolvedValueOnce(chatResponse('recovered on secondary'))
+    const providers = [provider({ id: 'stream-primary' }), provider({ id: 'stream-secondary' })]
+    const first = createGateway(providers, fetchMock as unknown as typeof fetch)
+    await expect(first.stream([{ role: 'user', content: 'hi' }], { onText: () => {} })).rejects.toBeInstanceOf(
+      GatewayStreamInterruptedError,
+    )
+
+    const rebuilt = createGateway(providers, fetchMock as unknown as typeof fetch)
+    const result = await rebuilt.complete([{ role: 'user', content: 'next turn' }])
+    expect(result.provider).toBe('stream-secondary')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('terminates the turn when only a reasoning delta streamed before the failure', async () => {

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -269,7 +269,7 @@ describe('gateway recent-failure ordering', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('does not transfer failure memory to an edited endpoint', async () => {
+  it('does not transfer failure memory to an edited model', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(new Response('boom', { status: 503 }))
@@ -281,6 +281,38 @@ describe('gateway recent-failure ordering', () => {
     const result = await createGateway(edited, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'second' }])
     expect(result.provider).toBe('primary')
     expect(fetchMock.mock.calls[0]![0]).toBe('https://primary.example.com/v1/chat/completions')
+  })
+
+  it('does not transfer failure memory to an edited base URL', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('fallback'))
+    await createGateway(providers, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }])
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('edited endpoint'))
+    const edited = [provider({ ...providers[0], baseUrl: 'https://replacement.example.com/v1' }), providers[1]!]
+    const result = await createGateway(edited, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'second' }])
+    expect(result.provider).toBe('primary')
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://replacement.example.com/v1/chat/completions')
+  })
+
+  it('excludes URL credentials and query parameters from failure identity', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(chatResponse('fallback'))
+    const credentialed = [
+      provider({ ...providers[0], baseUrl: 'https://user:password@primary.example.com/v1?token=secret' }),
+      providers[1]!,
+    ]
+    await createGateway(credentialed, fetchMock as unknown as typeof fetch).complete([{ role: 'user', content: 'first' }])
+
+    fetchMock.mockReset().mockResolvedValue(chatResponse('next turn'))
+    const sanitized = createGateway(providers, fetchMock as unknown as typeof fetch)
+    expect((await sanitized.complete([{ role: 'user', content: 'second' }])).provider).toBe('secondary')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://secondary.example.com/v1/chat/completions')
   })
 })
 


### PR DESCRIPTION
## Summary

Keeps recent Operator provider failures in process-local memory and temporarily moves those providers behind endpoints without recent failures. Failed providers remain eligible as fallback, a successful request clears their penalty immediately, configured priority returns after one minute, and explicit per-request preferences still take precedence.

The state is scoped to the provider transport, contains endpoint identity but no credentials, survives per-request gateway reconstruction, and intentionally adds no Redis dependency or configuration knobs.

## Related Issue

Fixes #347

Related: #345 / #396. The combined retry and recent-failure changes merge without conflicts and pass the gateway suite together.

## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore

## How Was This Tested?

- [x] Local run
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested (explain why)

Notes:

- Focused gateway suite: 58/58 tests, repeated 10 consecutive times (580/580 total)
- Complete API matrix: 77 files, 1,354 tests
- Combined with #345 retry commit: 65/65 gateway tests
- Repository style, TypeScript build, lint, and typecheck
- Documentation production build and docs-version verification
- Canonical `pnpm run ci` completed all TypeScript stages and all 18 TypeScript package suites; local execution then stopped at `test:go` because Go is not installed in this environment (`spawnSync go ENOENT`). Hosted CI covers the remaining platform matrix.

## CE & Security Check

- [x] Targets **Caracal OpenSource** only (no EE code)
- [x] No secrets or credentials committed

## Screenshots / Demos (if UI or UX)

Not applicable; no UI changes.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Major new functionality includes automated tests (required)
- [x] Bug fixes include a regression test (required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Model endpoints that recently fail are temporarily deprioritized during failover while remaining available as fallback options.
  * Successful requests immediately restore endpoint priority.
  * Endpoint priority returns to its configured order after the recovery window or an API process restart.
  * Streaming failures are considered when selecting the next endpoint.

* **Documentation**
  * Added guidance explaining endpoint failover and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->