### PR TITLE
fix: persist Operator run token usage

### DIFF
--- a/apps/api/src/operator-gateway.ts
+++ b/apps/api/src/operator-gateway.ts
@@ -124,6 +124,15 @@ export interface GatewayUsage {
   // The distinct providers that served a completion this request, in first-served order. More than
   // one entry, or a single entry that is not the failover order's primary, means Caracal fell back.
   providers: string[]
+  // Token totals grouped by the provider/model pair that produced them. A turn can use more than
+  // one pair when an early completion succeeds on the primary and a later one fails over, so this
+  // breakdown is the authoritative attribution for historical cost analysis.
+  byProviderModel: {
+    provider: string
+    model: string
+    inputTokens: number
+    outputTokens: number
+  }[]
 }
 
 // No provider is configured, so the AI tier is off. Distinct from a call failure so
@@ -588,17 +597,27 @@ export function withUsage(gateway: Gateway, options: { maxCalls?: number } = {})
   let lastProvider: string | null = null
   let lastModel: string | null = null
   const servedProviders: string[] = []
+  const byProviderModel: GatewayUsage['byProviderModel'] = []
   const maxCalls = options.maxCalls
   const guard = () => {
     if (maxCalls !== undefined && maxCalls > 0 && calls >= maxCalls) throw new GatewayBudgetError(maxCalls)
     calls += 1
   }
   const record = (provider: string, model: string, promptTokens?: number, completionTokens?: number) => {
-    inputTokens += promptTokens ?? 0
-    outputTokens += completionTokens ?? 0
+    const input = promptTokens ?? 0
+    const output = completionTokens ?? 0
+    inputTokens += input
+    outputTokens += output
     lastProvider = provider
     lastModel = model
     if (!servedProviders.includes(provider)) servedProviders.push(provider)
+    const attributed = byProviderModel.find((entry) => entry.provider === provider && entry.model === model)
+    if (attributed) {
+      attributed.inputTokens += input
+      attributed.outputTokens += output
+    } else {
+      byProviderModel.push({ provider, model, inputTokens: input, outputTokens: output })
+    }
   }
   const tracked: Gateway = {
     status: () => gateway.status(),
@@ -624,7 +643,14 @@ export function withUsage(gateway: Gateway, options: { maxCalls?: number } = {})
   }
   return {
     gateway: tracked,
-    usage: () => ({ inputTokens, outputTokens, provider: lastProvider, model: lastModel, providers: [...servedProviders] }),
+    usage: () => ({
+      inputTokens,
+      outputTokens,
+      provider: lastProvider,
+      model: lastModel,
+      providers: [...servedProviders],
+      byProviderModel: byProviderModel.map((entry) => ({ ...entry })),
+    }),
   }
 }
 

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -47,6 +47,7 @@ import {
   GatewayBudgetError,
   GatewayStreamInterruptedError,
   type Gateway,
+  type GatewayUsage,
   type ProviderConfig,
 } from '../operator-gateway.js'
 import { type GovernanceLimits } from '../operator-ai-governance.js'
@@ -83,7 +84,7 @@ const CONVERSATION_SELECT =
 // honest numeric type keeps the approval and execution bodies from rejecting a stringified seq.
 const TURN_SELECT = 'id, conversation_id, seq::int AS seq, role, kind, content, actor_id, created_at'
 const MESSAGE_RUN_SELECT =
-  'id, zone_id, conversation_id, client_message_id, server_message_turn_id, correlation_id, state, actor_id, provider_id, reason, error_code, error_detail, deadline_at, started_at, updated_at, completed_at, last_event_seq::int AS last_event_seq'
+  'id, zone_id, conversation_id, client_message_id, server_message_turn_id, correlation_id, state, actor_id, provider_id, reason, error_code, error_detail, deadline_at, started_at, updated_at, completed_at, last_event_seq::int AS last_event_seq, input_tokens::int AS input_tokens, output_tokens::int AS output_tokens, served_provider_id, served_model'
 
 const CreateConversationBody = z
   .object({
@@ -289,6 +290,10 @@ interface MessageRunRow {
   updated_at: string
   completed_at: string | null
   last_event_seq: number
+  input_tokens: number
+  output_tokens: number
+  served_provider_id: string | null
+  served_model: string | null
 }
 
 interface PublicMessageRun {
@@ -302,6 +307,9 @@ interface PublicMessageRun {
   deadline_at: string | null
   completed_at: string | null
   last_event_seq: number
+  usage: { input_tokens: number; output_tokens: number; total_tokens: number }
+  provider: string | null
+  model: string | null
 }
 
 function publicMessageRun(run: MessageRunRow): PublicMessageRun {
@@ -316,6 +324,13 @@ function publicMessageRun(run: MessageRunRow): PublicMessageRun {
     deadline_at: run.deadline_at,
     completed_at: run.completed_at,
     last_event_seq: run.last_event_seq,
+    usage: {
+      input_tokens: run.input_tokens,
+      output_tokens: run.output_tokens,
+      total_tokens: run.input_tokens + run.output_tokens,
+    },
+    provider: run.served_provider_id,
+    model: run.served_model,
   }
 }
 
@@ -328,6 +343,7 @@ async function writeMessageRunEventLocked(
     errorCode?: string | null
     errorDetail?: string | null
     payload?: Record<string, unknown>
+    usage?: GatewayUsage
   },
 ): Promise<MessageRunRow> {
   assertMessageRunTransition(input.run.state, input.state)
@@ -358,12 +374,52 @@ async function writeMessageRunEventLocked(
          error_detail = COALESCE($5, error_detail),
          completed_at = CASE WHEN $6 THEN COALESCE(completed_at, now()) ELSE completed_at END,
          last_event_seq = $7,
+         input_tokens = CASE WHEN $8::boolean THEN $9 ELSE input_tokens END,
+         output_tokens = CASE WHEN $8::boolean THEN $10 ELSE output_tokens END,
+         served_provider_id = CASE WHEN $8::boolean THEN $11 ELSE served_provider_id END,
+         served_model = CASE WHEN $8::boolean THEN $12 ELSE served_model END,
          updated_at = now()
      WHERE id = $1
      RETURNING ${MESSAGE_RUN_SELECT}`,
-    [input.run.id, input.state, input.reason ?? null, input.errorCode ?? null, input.errorDetail ?? null, terminal, eventSeq],
+    [
+      input.run.id,
+      input.state,
+      input.reason ?? null,
+      input.errorCode ?? null,
+      input.errorDetail ?? null,
+      terminal,
+      eventSeq,
+      input.usage !== undefined,
+      input.usage?.inputTokens ?? 0,
+      input.usage?.outputTokens ?? 0,
+      input.usage?.provider ?? null,
+      input.usage?.model ?? null,
+    ],
   )
   return rows[0]
+}
+
+// Persists the final usage snapshot when another actor already settled the run (for example, a
+// cancellation racing a model response). The model work still spent tokens, so the terminal state
+// must not erase its cost. Replacing the snapshot is idempotent for a retried response path.
+async function writeMessageRunUsageLocked(client: TxClient, run: MessageRunRow, usage: GatewayUsage): Promise<MessageRunRow | null> {
+  const { rows } = await client.query<MessageRunRow>(
+    `UPDATE operator_message_runs
+     SET input_tokens = $2,
+         output_tokens = $3,
+         served_provider_id = $4,
+         served_model = $5,
+         updated_at = now()
+     WHERE id = $1
+     RETURNING ${MESSAGE_RUN_SELECT}`,
+    [run.id, usage.inputTokens, usage.outputTokens, usage.provider, usage.model],
+  )
+  return rows[0] ?? null
+}
+
+async function persistMessageRunUsage(db: DB, run: MessageRunRow | null, usage: GatewayUsage): Promise<MessageRunRow | null> {
+  if (!run) return null
+  return withTransaction(db, (client) => writeMessageRunUsageLocked(client, run, usage))
 }
 
 type MessageRunStartOutcome =
@@ -460,7 +516,13 @@ async function transitionMessageRun(
   db: DB,
   run: MessageRunRow | null,
   state: MessageRunState,
-  options: { reason?: string | null; errorCode?: string | null; errorDetail?: string | null; payload?: Record<string, unknown> } = {},
+  options: {
+    reason?: string | null
+    errorCode?: string | null
+    errorDetail?: string | null
+    payload?: Record<string, unknown>
+    usage?: GatewayUsage
+  } = {},
 ): Promise<MessageRunRow | null> {
   if (!run) return null
   return withTransaction(db, async (client) => {
@@ -471,7 +533,9 @@ async function transitionMessageRun(
     // A run that already settled - a concurrent cancel, the deadline reaper - stays as it settled;
     // the losing transition observes the terminal row instead of throwing, so a raced completion
     // never turns a deliberate cancellation into a 500.
-    if (isTerminalMessageRunState(rows[0].state)) return rows[0]
+    if (isTerminalMessageRunState(rows[0].state)) {
+      return options.usage ? writeMessageRunUsageLocked(client, rows[0], options.usage) : rows[0]
+    }
     return writeMessageRunEventLocked(client, {
       run: rows[0],
       state,
@@ -479,6 +543,7 @@ async function transitionMessageRun(
       errorCode: options.errorCode,
       errorDetail: options.errorDetail,
       payload: options.payload,
+      usage: options.usage,
     })
   })
 }
@@ -2226,12 +2291,16 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       body: Record<string, unknown>,
       runState?: { state: MessageRunState; reason?: string; errorCode?: string; errorDetail?: string },
     ) => {
+      const usage = tracked.usage()
       if (runState) {
         messageRun = await transitionMessageRun(fastify.db, messageRun, runState.state, {
           reason: runState.reason,
           errorCode: runState.errorCode,
           errorDetail: runState.errorDetail,
+          usage,
         })
+      } else if (messageRun) {
+        messageRun = await persistMessageRunUsage(fastify.db, messageRun, usage)
       }
       const payload = messageRun ? { ...body, message_run: publicMessageRun(messageRun) } : body
       if (!wantsStream) return reply.code(resultStatus).send(payload)
@@ -2630,7 +2699,11 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       // through to the framework's error handler; it is closed as a terminal error frame. Durable
       // JSON requests also settle the run before returning the same terminal failure shape.
       if (wantsStream) {
-        messageRun = await transitionMessageRun(fastify.db, messageRun, 'failed', { reason: 'ai_failed', errorCode: 'ai_failed' })
+        messageRun = await transitionMessageRun(fastify.db, messageRun, 'failed', {
+          reason: 'ai_failed',
+          errorCode: 'ai_failed',
+          usage: tracked.usage(),
+        })
         writeSseEvent(reply, 'error', {
           error: 'ai_failed',
           status: 500,

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -84,7 +84,7 @@ const CONVERSATION_SELECT =
 // honest numeric type keeps the approval and execution bodies from rejecting a stringified seq.
 const TURN_SELECT = 'id, conversation_id, seq::int AS seq, role, kind, content, actor_id, created_at'
 const MESSAGE_RUN_SELECT =
-  'id, zone_id, conversation_id, client_message_id, server_message_turn_id, correlation_id, state, actor_id, provider_id, reason, error_code, error_detail, deadline_at, started_at, updated_at, completed_at, last_event_seq::int AS last_event_seq, input_tokens::int AS input_tokens, output_tokens::int AS output_tokens, served_provider_id, served_model'
+  'id, zone_id, conversation_id, client_message_id, server_message_turn_id, correlation_id, state, actor_id, provider_id, reason, error_code, error_detail, deadline_at, started_at, updated_at, completed_at, last_event_seq::int AS last_event_seq, input_tokens::int AS input_tokens, output_tokens::int AS output_tokens, usage_by_provider_model, served_provider_id, served_model'
 
 const CreateConversationBody = z
   .object({
@@ -292,8 +292,16 @@ interface MessageRunRow {
   last_event_seq: number
   input_tokens: number
   output_tokens: number
+  usage_by_provider_model: ProviderModelUsage[]
   served_provider_id: string | null
   served_model: string | null
+}
+
+interface ProviderModelUsage {
+  provider: string
+  model: string
+  input_tokens: number
+  output_tokens: number
 }
 
 interface PublicMessageRun {
@@ -307,7 +315,12 @@ interface PublicMessageRun {
   deadline_at: string | null
   completed_at: string | null
   last_event_seq: number
-  usage: { input_tokens: number; output_tokens: number; total_tokens: number }
+  usage: {
+    input_tokens: number
+    output_tokens: number
+    total_tokens: number
+    by_provider_model: (ProviderModelUsage & { total_tokens: number })[]
+  }
   provider: string | null
   model: string | null
 }
@@ -328,10 +341,23 @@ function publicMessageRun(run: MessageRunRow): PublicMessageRun {
       input_tokens: run.input_tokens,
       output_tokens: run.output_tokens,
       total_tokens: run.input_tokens + run.output_tokens,
+      by_provider_model: run.usage_by_provider_model.map((entry) => ({
+        ...entry,
+        total_tokens: entry.input_tokens + entry.output_tokens,
+      })),
     },
     provider: run.served_provider_id,
     model: run.served_model,
   }
+}
+
+function providerModelUsage(usage: GatewayUsage): ProviderModelUsage[] {
+  return usage.byProviderModel.map((entry) => ({
+    provider: entry.provider,
+    model: entry.model,
+    input_tokens: entry.inputTokens,
+    output_tokens: entry.outputTokens,
+  }))
 }
 
 async function writeMessageRunEventLocked(
@@ -376,8 +402,9 @@ async function writeMessageRunEventLocked(
          last_event_seq = $7,
          input_tokens = CASE WHEN $8::boolean THEN $9 ELSE input_tokens END,
          output_tokens = CASE WHEN $8::boolean THEN $10 ELSE output_tokens END,
-         served_provider_id = CASE WHEN $8::boolean THEN $11 ELSE served_provider_id END,
-         served_model = CASE WHEN $8::boolean THEN $12 ELSE served_model END,
+         usage_by_provider_model = CASE WHEN $8::boolean THEN $11::jsonb ELSE usage_by_provider_model END,
+         served_provider_id = CASE WHEN $8::boolean THEN $12 ELSE served_provider_id END,
+         served_model = CASE WHEN $8::boolean THEN $13 ELSE served_model END,
          updated_at = now()
      WHERE id = $1
      RETURNING ${MESSAGE_RUN_SELECT}`,
@@ -392,6 +419,7 @@ async function writeMessageRunEventLocked(
       input.usage !== undefined,
       input.usage?.inputTokens ?? 0,
       input.usage?.outputTokens ?? 0,
+      JSON.stringify(input.usage ? providerModelUsage(input.usage) : []),
       input.usage?.provider ?? null,
       input.usage?.model ?? null,
     ],
@@ -407,12 +435,13 @@ async function writeMessageRunUsageLocked(client: TxClient, run: MessageRunRow, 
     `UPDATE operator_message_runs
      SET input_tokens = $2,
          output_tokens = $3,
-         served_provider_id = $4,
-         served_model = $5,
+         usage_by_provider_model = $4::jsonb,
+         served_provider_id = $5,
+         served_model = $6,
          updated_at = now()
      WHERE id = $1
      RETURNING ${MESSAGE_RUN_SELECT}`,
-    [run.id, usage.inputTokens, usage.outputTokens, usage.provider, usage.model],
+    [run.id, usage.inputTokens, usage.outputTokens, JSON.stringify(providerModelUsage(usage)), usage.provider, usage.model],
   )
   return rows[0] ?? null
 }
@@ -2235,6 +2264,10 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
           input_tokens: usage.inputTokens,
           output_tokens: usage.outputTokens,
           total_tokens: usage.inputTokens + usage.outputTokens,
+          by_provider_model: providerModelUsage(usage).map((entry) => ({
+            ...entry,
+            total_tokens: entry.input_tokens + entry.output_tokens,
+          })),
         },
         model: reporting?.model ?? null,
         provider: reporting?.id ?? null,

--- a/apps/web/src/platform/api/types.ts
+++ b/apps/web/src/platform/api/types.ts
@@ -1175,6 +1175,15 @@ export interface OperatorUsage {
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
+  // A run may move between providers across model calls. This breakdown is the authoritative cost
+  // attribution; the top-level provider/model describe only the most recent successful call.
+  by_provider_model: Array<{
+    provider: string;
+    model: string;
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+  }>;
 }
 
 export interface OperatorUsageMeta {
@@ -1217,8 +1226,8 @@ export interface OperatorMessageRun {
   deadline_at: string | null;
   completed_at: string | null;
   last_event_seq: number;
-  // Durable usage for this run, retained with the actual provider and model that served its most
-  // recent successful completion so historical cost analysis does not depend on the live response.
+  // Durable usage for this run, including a provider/model breakdown so historical cost analysis
+  // does not depend on the live response or misattribute a mixed-provider run.
   usage: OperatorUsage;
   provider: string | null;
   model: string | null;

--- a/apps/web/src/platform/api/types.ts
+++ b/apps/web/src/platform/api/types.ts
@@ -1217,6 +1217,11 @@ export interface OperatorMessageRun {
   deadline_at: string | null;
   completed_at: string | null;
   last_event_seq: number;
+  // Durable usage for this run, retained with the actual provider and model that served its most
+  // recent successful completion so historical cost analysis does not depend on the live response.
+  usage: OperatorUsage;
+  provider: string | null;
+  model: string | null;
 }
 
 // The advisory severity of a single security finding. Advisory only: it informs the human who

--- a/apps/web/src/platform/api/types.ts
+++ b/apps/web/src/platform/api/types.ts
@@ -1176,7 +1176,8 @@ export interface OperatorUsage {
   output_tokens: number;
   total_tokens: number;
   // A run may move between providers across model calls. This breakdown is the authoritative cost
-  // attribution; the top-level provider/model describe only the most recent successful call.
+  // attribution. The top-level provider/model retain the latest serving attribution and can be
+  // present when the run ultimately fails, is cancelled, or times out.
   by_provider_model: Array<{
     provider: string;
     model: string;

--- a/docs/src/content/docs/concepts/operator.mdx
+++ b/docs/src/content/docs/concepts/operator.mdx
@@ -48,7 +48,7 @@ Every conversation runs in one of two modes, enforced by Caracal and never chose
 
 Ask mode is enforced in two independent places - the planning skill is never selected, and the change endpoints refuse outright - so a read-only conversation is provably write-incapable.
 
-Each durable message run records its input and output token totals together with the provider and model that actually served it. This usage survives the live response for historical cost analysis; provider credentials and prompts are never stored in the usage record.
+Each durable message run records its input and output token totals with a breakdown for every provider and model that served one of its completions. This usage survives the live response for accurate historical cost analysis even when a later call fails over; provider credentials and prompts are never stored in the usage record.
 
 ## Autopilot
 

--- a/docs/src/content/docs/concepts/operator.mdx
+++ b/docs/src/content/docs/concepts/operator.mdx
@@ -48,6 +48,8 @@ Every conversation runs in one of two modes, enforced by Caracal and never chose
 
 Ask mode is enforced in two independent places - the planning skill is never selected, and the change endpoints refuse outright - so a read-only conversation is provably write-incapable.
 
+Each durable message run records its input and output token totals together with the provider and model that actually served it. This usage survives the live response for historical cost analysis; provider credentials and prompts are never stored in the usage record.
+
 ## Autopilot
 
 In agent mode you can engage **autopilot**, which lets Caracal auto-satisfy the approval step for every plan in the conversation. Engaging it is an explicit opt-in to acting without a human in the loop; it is off by default and per conversation, and a platform-level master switch must also be on. Auto-approval never widens authority - the governed execute path still enforces the capability allowlist, the least-privilege executor token, and zone isolation on every apply. Autopilot defers while a plan still needs credentials from the console's secure prompt and stops when a preview shows the plan cannot apply. A deployment can also bound an engaged conversation with a **write budget**: once the cumulative auto-approved write operations would exceed it, autopilot pauses, records the pause in the conversation ledger, and the plan waits for explicit human approval. The master switch is a single kill switch that stops all auto-approval on the next turn.

--- a/infra/postgres/migrations/0003_operator_run_token_usage.down.sql
+++ b/infra/postgres/migrations/0003_operator_run_token_usage.down.sql
@@ -1,0 +1,12 @@
+-- Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+-- Caracal, a product of Garudex Labs
+--
+-- Reverses durable Operator message-run token usage; development and CI only.
+
+ALTER TABLE public.operator_message_runs
+    DROP CONSTRAINT IF EXISTS operator_message_runs_output_tokens_check,
+    DROP CONSTRAINT IF EXISTS operator_message_runs_input_tokens_check,
+    DROP COLUMN IF EXISTS served_model,
+    DROP COLUMN IF EXISTS served_provider_id,
+    DROP COLUMN IF EXISTS output_tokens,
+    DROP COLUMN IF EXISTS input_tokens;

--- a/infra/postgres/migrations/0003_operator_run_token_usage.down.sql
+++ b/infra/postgres/migrations/0003_operator_run_token_usage.down.sql
@@ -4,9 +4,11 @@
 -- Reverses durable Operator message-run token usage; development and CI only.
 
 ALTER TABLE public.operator_message_runs
+    DROP CONSTRAINT IF EXISTS operator_message_runs_usage_by_provider_model_check,
     DROP CONSTRAINT IF EXISTS operator_message_runs_output_tokens_check,
     DROP CONSTRAINT IF EXISTS operator_message_runs_input_tokens_check,
     DROP COLUMN IF EXISTS served_model,
     DROP COLUMN IF EXISTS served_provider_id,
+    DROP COLUMN IF EXISTS usage_by_provider_model,
     DROP COLUMN IF EXISTS output_tokens,
     DROP COLUMN IF EXISTS input_tokens;

--- a/infra/postgres/migrations/0003_operator_run_token_usage.up.sql
+++ b/infra/postgres/migrations/0003_operator_run_token_usage.up.sql
@@ -6,7 +6,23 @@
 ALTER TABLE public.operator_message_runs
     ADD COLUMN input_tokens bigint DEFAULT 0 NOT NULL,
     ADD COLUMN output_tokens bigint DEFAULT 0 NOT NULL,
+    ADD COLUMN usage_by_provider_model jsonb DEFAULT '[]'::jsonb NOT NULL,
     ADD COLUMN served_provider_id text,
-    ADD COLUMN served_model text,
-    ADD CONSTRAINT operator_message_runs_input_tokens_check CHECK (input_tokens >= 0),
-    ADD CONSTRAINT operator_message_runs_output_tokens_check CHECK (output_tokens >= 0);
+    ADD COLUMN served_model text;
+
+-- NOT VALID makes each check enforce new writes immediately without holding the stronger ALTER
+-- lock while PostgreSQL scans existing runs. Validation uses a lower lock in its own statement.
+ALTER TABLE public.operator_message_runs
+    ADD CONSTRAINT operator_message_runs_input_tokens_check CHECK (input_tokens >= 0) NOT VALID,
+    ADD CONSTRAINT operator_message_runs_output_tokens_check CHECK (output_tokens >= 0) NOT VALID,
+    ADD CONSTRAINT operator_message_runs_usage_by_provider_model_check
+        CHECK (jsonb_typeof(usage_by_provider_model) = 'array') NOT VALID;
+
+ALTER TABLE public.operator_message_runs
+    VALIDATE CONSTRAINT operator_message_runs_input_tokens_check;
+
+ALTER TABLE public.operator_message_runs
+    VALIDATE CONSTRAINT operator_message_runs_output_tokens_check;
+
+ALTER TABLE public.operator_message_runs
+    VALIDATE CONSTRAINT operator_message_runs_usage_by_provider_model_check;

--- a/infra/postgres/migrations/0003_operator_run_token_usage.up.sql
+++ b/infra/postgres/migrations/0003_operator_run_token_usage.up.sql
@@ -1,0 +1,12 @@
+-- Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+-- Caracal, a product of Garudex Labs
+--
+-- Persists the model usage already calculated for each durable Operator message run.
+
+ALTER TABLE public.operator_message_runs
+    ADD COLUMN input_tokens bigint DEFAULT 0 NOT NULL,
+    ADD COLUMN output_tokens bigint DEFAULT 0 NOT NULL,
+    ADD COLUMN served_provider_id text,
+    ADD COLUMN served_model text,
+    ADD CONSTRAINT operator_message_runs_input_tokens_check CHECK (input_tokens >= 0),
+    ADD CONSTRAINT operator_message_runs_output_tokens_check CHECK (output_tokens >= 0);

--- a/infra/postgres/migrations/0003_operator_run_token_usage.up.sql
+++ b/infra/postgres/migrations/0003_operator_run_token_usage.up.sql
@@ -10,19 +10,11 @@ ALTER TABLE public.operator_message_runs
     ADD COLUMN served_provider_id text,
     ADD COLUMN served_model text;
 
--- NOT VALID makes each check enforce new writes immediately without holding the stronger ALTER
--- lock while PostgreSQL scans existing runs. Validation uses a lower lock in its own statement.
+-- NOT VALID makes each check enforce new writes immediately without scanning existing runs while
+-- migrate.sh holds this file's transaction open. Existing rows received known-safe defaults; a
+-- later migration may validate the checks in a separate transaction if planner trust is needed.
 ALTER TABLE public.operator_message_runs
     ADD CONSTRAINT operator_message_runs_input_tokens_check CHECK (input_tokens >= 0) NOT VALID,
     ADD CONSTRAINT operator_message_runs_output_tokens_check CHECK (output_tokens >= 0) NOT VALID,
     ADD CONSTRAINT operator_message_runs_usage_by_provider_model_check
         CHECK (jsonb_typeof(usage_by_provider_model) = 'array') NOT VALID;
-
-ALTER TABLE public.operator_message_runs
-    VALIDATE CONSTRAINT operator_message_runs_input_tokens_check;
-
-ALTER TABLE public.operator_message_runs
-    VALIDATE CONSTRAINT operator_message_runs_output_tokens_check;
-
-ALTER TABLE public.operator_message_runs
-    VALIDATE CONSTRAINT operator_message_runs_usage_by_provider_model_check;

--- a/infra/postgres/scripts/verify.sh
+++ b/infra/postgres/scripts/verify.sh
@@ -74,18 +74,18 @@ echo "  lease generation column OK"
 
 echo ""
 echo "=== Operator observability: durable message-run token usage ==="
-for column in input_tokens output_tokens served_provider_id served_model; do
+for column in input_tokens output_tokens usage_by_provider_model served_provider_id served_model; do
   if [ "$(scalar "SELECT count(*) FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'operator_message_runs' AND column_name = '$column';")" != "1" ]; then
     echo "  FAIL: operator_message_runs.$column missing"
     exit 1
   fi
   echo "  $column OK"
 done
-if [ "$(scalar "SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.operator_message_runs'::regclass AND conname IN ('operator_message_runs_input_tokens_check', 'operator_message_runs_output_tokens_check');")" != "2" ]; then
-  echo "  FAIL: operator message-run token checks missing"
+if [ "$(scalar "SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.operator_message_runs'::regclass AND convalidated AND conname IN ('operator_message_runs_input_tokens_check', 'operator_message_runs_output_tokens_check', 'operator_message_runs_usage_by_provider_model_check');")" != "3" ]; then
+  echo "  FAIL: operator message-run usage checks missing or unvalidated"
   exit 1
 fi
-echo "  non-negative token checks OK"
+echo "  token and attribution checks OK"
 
 echo ""
 echo "=== Migration: retired tables absent ==="

--- a/infra/postgres/scripts/verify.sh
+++ b/infra/postgres/scripts/verify.sh
@@ -81,11 +81,11 @@ for column in input_tokens output_tokens usage_by_provider_model served_provider
   fi
   echo "  $column OK"
 done
-if [ "$(scalar "SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.operator_message_runs'::regclass AND convalidated AND conname IN ('operator_message_runs_input_tokens_check', 'operator_message_runs_output_tokens_check', 'operator_message_runs_usage_by_provider_model_check');")" != "3" ]; then
-  echo "  FAIL: operator message-run usage checks missing or unvalidated"
+if [ "$(scalar "SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.operator_message_runs'::regclass AND conname IN ('operator_message_runs_input_tokens_check', 'operator_message_runs_output_tokens_check', 'operator_message_runs_usage_by_provider_model_check');")" != "3" ]; then
+  echo "  FAIL: operator message-run usage checks missing"
   exit 1
 fi
-echo "  token and attribution checks OK"
+echo "  token and attribution checks installed"
 
 echo ""
 echo "=== Migration: retired tables absent ==="

--- a/infra/postgres/scripts/verify.sh
+++ b/infra/postgres/scripts/verify.sh
@@ -73,6 +73,21 @@ fi
 echo "  lease generation column OK"
 
 echo ""
+echo "=== Operator observability: durable message-run token usage ==="
+for column in input_tokens output_tokens served_provider_id served_model; do
+  if [ "$(scalar "SELECT count(*) FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'operator_message_runs' AND column_name = '$column';")" != "1" ]; then
+    echo "  FAIL: operator_message_runs.$column missing"
+    exit 1
+  fi
+  echo "  $column OK"
+done
+if [ "$(scalar "SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.operator_message_runs'::regclass AND conname IN ('operator_message_runs_input_tokens_check', 'operator_message_runs_output_tokens_check');")" != "2" ]; then
+  echo "  FAIL: operator message-run token checks missing"
+  exit 1
+fi
+echo "  non-negative token checks OK"
+
+echo ""
 echo "=== Migration: retired tables absent ==="
 RETIRED_TABLES=(
   gateway_binding_revision

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -523,9 +523,9 @@ describe('withUsage', () => {
   it('records the provider and model that served, tracking a failover across calls', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(chatResponse('one'))
+      .mockResolvedValueOnce(chatResponse('one', { prompt_tokens: 100, completion_tokens: 20 }))
       .mockRejectedValueOnce(new TypeError('connection refused'))
-      .mockResolvedValueOnce(chatResponse('two'))
+      .mockResolvedValueOnce(chatResponse('two', { prompt_tokens: 30, completion_tokens: 5 }))
     const base = createGateway(
       [provider({ id: 'primary', model: 'gpt-a' }), provider({ id: 'secondary', model: 'gpt-b' })],
       fetchMock as unknown as typeof fetch,
@@ -535,7 +535,17 @@ describe('withUsage', () => {
     await gateway.complete([{ role: 'user', content: 'b' }])
     // The first call was served by the primary; the second failed over to the secondary, so both
     // providers are recorded in served order and the last served provider is the secondary.
-    expect(usage()).toMatchObject({ provider: 'secondary', model: 'gpt-b', providers: ['primary', 'secondary'] })
+    expect(usage()).toMatchObject({
+      inputTokens: 130,
+      outputTokens: 25,
+      provider: 'secondary',
+      model: 'gpt-b',
+      providers: ['primary', 'secondary'],
+      byProviderModel: [
+        { provider: 'primary', model: 'gpt-a', inputTokens: 100, outputTokens: 20 },
+        { provider: 'secondary', model: 'gpt-b', inputTokens: 30, outputTokens: 5 },
+      ],
+    })
   })
 
   it('reports a null served provider when no completion succeeded', async () => {

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -2260,6 +2260,10 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
               updated_at: '2026-07-01T00:00:01Z',
               completed_at: null,
               last_event_seq: 3,
+              input_tokens: 42,
+              output_tokens: 7,
+              served_provider_id: 'primary',
+              served_model: 'gpt-x',
             },
           ],
         }
@@ -2277,14 +2281,26 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
       intent: 'message_run',
       ok: true,
       duplicate: true,
-      message_run: { id: 'run-1', client_message_id: 'msg-1', correlation_id: 'corr-1', state: 'waiting_for_model' },
+      message_run: {
+        id: 'run-1',
+        client_message_id: 'msg-1',
+        correlation_id: 'corr-1',
+        state: 'waiting_for_model',
+        usage: { input_tokens: 42, output_tokens: 7, total_tokens: 49 },
+        provider: 'primary',
+        model: 'gpt-x',
+      },
     })
     expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(0)
     expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('INSERT INTO operator_turns'))).toBe(false)
   })
 
   it('records a durable message run and marks it failed when the model budget stops the turn', async () => {
-    const fetchImpl = fetchReturning('{"tier":"read"}', 'answer never reached')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ choices: [{ message: { content: '{"tier":"read"}' } }], usage: { prompt_tokens: 10, completion_tokens: 2 } }),
+      ) as unknown as typeof fetch
     const { app, clientQuery, db } = buildApp(true, {
       aiProviders: [provider],
       fetchImpl,
@@ -2292,6 +2308,10 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     })
     let runState = 'queued'
     let lastEventSeq = 0
+    let inputTokens = 0
+    let outputTokens = 0
+    let servedProvider: string | null = null
+    let servedModel: string | null = null
     const run = (overrides: Record<string, unknown> = {}) => ({
       id: 'run-1',
       zone_id: 'z1',
@@ -2310,6 +2330,10 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
       updated_at: '2026-07-01T00:00:00Z',
       completed_at: null,
       last_event_seq: lastEventSeq,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      served_provider_id: servedProvider,
+      served_model: servedModel,
       ...overrides,
     })
     clientQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
@@ -2323,6 +2347,12 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
         if (params?.[1] === 'turn-1') return { rows: [run({ server_message_turn_id: 'turn-1' })] }
         runState = String(params?.[1] ?? runState)
         lastEventSeq = Number(params?.[6] ?? lastEventSeq)
+        if (params?.[7] === true) {
+          inputTokens = Number(params[8])
+          outputTokens = Number(params[9])
+          servedProvider = typeof params[10] === 'string' ? params[10] : null
+          servedModel = typeof params[11] === 'string' ? params[11] : null
+        }
         return {
           rows: [
             run({
@@ -2356,7 +2386,15 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     const body = JSON.parse(res.body)
     expect(body).toMatchObject({
       error: 'ai_budget_exceeded',
-      message_run: { client_message_id: 'msg-2', correlation_id: 'corr-2', state: 'failed', error_code: 'ai_budget_exceeded' },
+      message_run: {
+        client_message_id: 'msg-2',
+        correlation_id: 'corr-2',
+        state: 'failed',
+        error_code: 'ai_budget_exceeded',
+        usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        provider: 'primary',
+        model: 'gpt-x',
+      },
     })
     const messageInsert = clientQuery.mock.calls.find((call) => String(call[0]).includes('INSERT INTO operator_turns'))
     expect(messageInsert).toBeDefined()
@@ -3571,6 +3609,108 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     expect(body.usage).toEqual({ input_tokens: 520, output_tokens: 64, total_tokens: 584 })
   })
 
+  it('persists token usage and actual provider/model on the durable message run', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ choices: [{ message: { content: '{"tier":"read"}' } }], usage: { prompt_tokens: 120, completion_tokens: 4 } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ choices: [{ message: { content: 'Grounded answer.' } }], usage: { prompt_tokens: 400, completion_tokens: 60 } }),
+      ) as unknown as typeof fetch
+    const { app, clientQuery, db } = buildApp(true, { aiProviders: [provider], fetchImpl })
+    let state = 'queued'
+    let eventSeq = 0
+    let inputTokens = 0
+    let outputTokens = 0
+    let servedProvider: string | null = null
+    let servedModel: string | null = null
+    const run = (overrides: Record<string, unknown> = {}) => ({
+      id: 'run-usage',
+      zone_id: 'z1',
+      conversation_id: 'conv-1',
+      client_message_id: 'msg-usage',
+      server_message_turn_id: null,
+      correlation_id: 'corr-usage',
+      state,
+      actor_id: 'actor-1',
+      provider_id: null,
+      reason: null,
+      error_code: null,
+      error_detail: null,
+      deadline_at: '2026-07-01T00:02:00Z',
+      started_at: '2026-07-01T00:00:00Z',
+      updated_at: '2026-07-01T00:00:00Z',
+      completed_at: null,
+      last_event_seq: eventSeq,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      served_provider_id: servedProvider,
+      served_model: servedModel,
+      ...overrides,
+    })
+    let turn = 0
+    clientQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM operator_conversations')) {
+        return { rows: [{ status: 'active', mode: 'agent', autopilot: false, next_seq: turn + 1 }] }
+      }
+      if (sql.includes('WHERE conversation_id = $1 AND client_message_id = $2')) return { rows: [] }
+      if (sql.startsWith('INSERT INTO operator_message_runs')) return { rows: [run()] }
+      if (sql.startsWith('INSERT INTO operator_message_run_events')) return { rows: [] }
+      if (sql.startsWith('UPDATE operator_message_runs')) {
+        if (sql.includes('server_message_turn_id = $2')) return { rows: [run({ server_message_turn_id: 'turn-1' })] }
+        state = String(params?.[1] ?? state)
+        eventSeq = Number(params?.[6] ?? eventSeq)
+        if (params?.[7] === true) {
+          inputTokens = Number(params[8])
+          outputTokens = Number(params[9])
+          servedProvider = typeof params[10] === 'string' ? params[10] : null
+          servedModel = typeof params[11] === 'string' ? params[11] : null
+        }
+        return {
+          rows: [
+            run({
+              server_message_turn_id: 'turn-1',
+              reason: typeof params?.[2] === 'string' ? params[2] : null,
+              completed_at: state === 'completed' ? '2026-07-01T00:00:04Z' : null,
+            }),
+          ],
+        }
+      }
+      if (sql.includes('SELECT') && sql.includes('FROM operator_message_runs')) {
+        return { rows: [run({ server_message_turn_id: 'turn-1' })] }
+      }
+      if (sql.startsWith('INSERT INTO operator_turns')) {
+        turn += 1
+        return { rows: [{ id: `turn-${turn}`, seq: turn, kind: turn === 1 ? 'message' : 'note' }] }
+      }
+      return { rows: [], rowCount: 1 }
+    })
+    db.query.mockImplementation(async (sql: string) =>
+      sql.includes('operator_governed') ? { rows: [{ name: 'Zone One', slug: 'z1', operator_governed: false }] } : { rows: [] },
+    )
+
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/message',
+      payload: { message: 'why was my agent denied', client_message_id: 'msg-usage', correlation_id: 'corr-usage' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(JSON.parse(res.body).message_run).toMatchObject({
+      id: 'run-usage',
+      state: 'completed',
+      usage: { input_tokens: 520, output_tokens: 64, total_tokens: 584 },
+      provider: 'primary',
+      model: 'gpt-x',
+    })
+    const terminalUpdate = clientQuery.mock.calls.find(
+      (call) => String(call[0]).includes('served_provider_id = CASE') && call[1]?.[1] === 'completed',
+    )
+    expect(terminalUpdate?.[1]?.slice(7, 12)).toEqual([true, 520, 64, 'primary', 'gpt-x'])
+  })
+
   it('reports the served model and a failover flag when the primary provider is unavailable', async () => {
     const first = { ...provider, id: 'first', model: 'model-a', apiKey: 'sk-first' }
     const second = { ...provider, id: 'second', model: 'model-b', apiKey: 'sk-second', contextWindow: 64000 }
@@ -3713,6 +3853,10 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message-runs/cancel'
     updated_at: '2026-07-01T00:00:01Z',
     completed_at: null,
     last_event_seq: 3,
+    input_tokens: 0,
+    output_tokens: 0,
+    served_provider_id: null,
+    served_model: null,
     ...overrides,
   })
 

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -2262,6 +2262,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
               last_event_seq: 3,
               input_tokens: 42,
               output_tokens: 7,
+              usage_by_provider_model: [{ provider: 'primary', model: 'gpt-x', input_tokens: 42, output_tokens: 7 }],
               served_provider_id: 'primary',
               served_model: 'gpt-x',
             },
@@ -2286,7 +2287,12 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
         client_message_id: 'msg-1',
         correlation_id: 'corr-1',
         state: 'waiting_for_model',
-        usage: { input_tokens: 42, output_tokens: 7, total_tokens: 49 },
+        usage: {
+          input_tokens: 42,
+          output_tokens: 7,
+          total_tokens: 49,
+          by_provider_model: [{ provider: 'primary', model: 'gpt-x', input_tokens: 42, output_tokens: 7, total_tokens: 49 }],
+        },
         provider: 'primary',
         model: 'gpt-x',
       },
@@ -2310,6 +2316,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     let lastEventSeq = 0
     let inputTokens = 0
     let outputTokens = 0
+    let usageByProviderModel: Record<string, unknown>[] = []
     let servedProvider: string | null = null
     let servedModel: string | null = null
     const run = (overrides: Record<string, unknown> = {}) => ({
@@ -2332,6 +2339,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
       last_event_seq: lastEventSeq,
       input_tokens: inputTokens,
       output_tokens: outputTokens,
+      usage_by_provider_model: usageByProviderModel,
       served_provider_id: servedProvider,
       served_model: servedModel,
       ...overrides,
@@ -2350,8 +2358,9 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
         if (params?.[7] === true) {
           inputTokens = Number(params[8])
           outputTokens = Number(params[9])
-          servedProvider = typeof params[10] === 'string' ? params[10] : null
-          servedModel = typeof params[11] === 'string' ? params[11] : null
+          usageByProviderModel = JSON.parse(String(params[10]))
+          servedProvider = typeof params[11] === 'string' ? params[11] : null
+          servedModel = typeof params[12] === 'string' ? params[12] : null
         }
         return {
           rows: [
@@ -2391,7 +2400,12 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
         correlation_id: 'corr-2',
         state: 'failed',
         error_code: 'ai_budget_exceeded',
-        usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        usage: {
+          input_tokens: 10,
+          output_tokens: 2,
+          total_tokens: 12,
+          by_provider_model: [{ provider: 'primary', model: 'gpt-x', input_tokens: 10, output_tokens: 2, total_tokens: 12 }],
+        },
         provider: 'primary',
         model: 'gpt-x',
       },
@@ -3606,23 +3620,32 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     const body = JSON.parse(res.body)
     expect(body.model).toBe('gpt-x')
     expect(body.max_tokens).toBe(128000)
-    expect(body.usage).toEqual({ input_tokens: 520, output_tokens: 64, total_tokens: 584 })
+    expect(body.usage).toEqual({
+      input_tokens: 520,
+      output_tokens: 64,
+      total_tokens: 584,
+      by_provider_model: [{ provider: 'primary', model: 'gpt-x', input_tokens: 520, output_tokens: 64, total_tokens: 584 }],
+    })
   })
 
-  it('persists token usage and actual provider/model on the durable message run', async () => {
+  it('persists token usage by provider/model when a later completion fails over', async () => {
+    const secondary = { ...provider, id: 'secondary', model: 'gpt-y', apiKey: 'sk-secondary' }
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
         jsonResponse({ choices: [{ message: { content: '{"tier":"read"}' } }], usage: { prompt_tokens: 120, completion_tokens: 4 } }),
       )
+      // A terminal response skips retries and moves this second model call to the next provider.
+      .mockResolvedValueOnce(jsonResponse({ error: { message: 'bad request' } }, 400))
       .mockResolvedValueOnce(
         jsonResponse({ choices: [{ message: { content: 'Grounded answer.' } }], usage: { prompt_tokens: 400, completion_tokens: 60 } }),
       ) as unknown as typeof fetch
-    const { app, clientQuery, db } = buildApp(true, { aiProviders: [provider], fetchImpl })
+    const { app, clientQuery, db } = buildApp(true, { aiProviders: [provider, secondary], fetchImpl })
     let state = 'queued'
     let eventSeq = 0
     let inputTokens = 0
     let outputTokens = 0
+    let usageByProviderModel: Record<string, unknown>[] = []
     let servedProvider: string | null = null
     let servedModel: string | null = null
     const run = (overrides: Record<string, unknown> = {}) => ({
@@ -3645,6 +3668,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
       last_event_seq: eventSeq,
       input_tokens: inputTokens,
       output_tokens: outputTokens,
+      usage_by_provider_model: usageByProviderModel,
       served_provider_id: servedProvider,
       served_model: servedModel,
       ...overrides,
@@ -3664,8 +3688,9 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
         if (params?.[7] === true) {
           inputTokens = Number(params[8])
           outputTokens = Number(params[9])
-          servedProvider = typeof params[10] === 'string' ? params[10] : null
-          servedModel = typeof params[11] === 'string' ? params[11] : null
+          usageByProviderModel = JSON.parse(String(params[10]))
+          servedProvider = typeof params[11] === 'string' ? params[11] : null
+          servedModel = typeof params[12] === 'string' ? params[12] : null
         }
         return {
           rows: [
@@ -3701,14 +3726,27 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     expect(JSON.parse(res.body).message_run).toMatchObject({
       id: 'run-usage',
       state: 'completed',
-      usage: { input_tokens: 520, output_tokens: 64, total_tokens: 584 },
-      provider: 'primary',
-      model: 'gpt-x',
+      usage: {
+        input_tokens: 520,
+        output_tokens: 64,
+        total_tokens: 584,
+        by_provider_model: [
+          { provider: 'primary', model: 'gpt-x', input_tokens: 120, output_tokens: 4, total_tokens: 124 },
+          { provider: 'secondary', model: 'gpt-y', input_tokens: 400, output_tokens: 60, total_tokens: 460 },
+        ],
+      },
+      provider: 'secondary',
+      model: 'gpt-y',
     })
     const terminalUpdate = clientQuery.mock.calls.find(
       (call) => String(call[0]).includes('served_provider_id = CASE') && call[1]?.[1] === 'completed',
     )
-    expect(terminalUpdate?.[1]?.slice(7, 12)).toEqual([true, 520, 64, 'primary', 'gpt-x'])
+    expect(terminalUpdate?.[1]?.slice(7, 10)).toEqual([true, 520, 64])
+    expect(JSON.parse(String(terminalUpdate?.[1]?.[10]))).toEqual([
+      { provider: 'primary', model: 'gpt-x', input_tokens: 120, output_tokens: 4 },
+      { provider: 'secondary', model: 'gpt-y', input_tokens: 400, output_tokens: 60 },
+    ])
+    expect(terminalUpdate?.[1]?.slice(11, 13)).toEqual(['secondary', 'gpt-y'])
   })
 
   it('reports the served model and a failover flag when the primary provider is unavailable', async () => {
@@ -3855,6 +3893,7 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message-runs/cancel'
     last_event_seq: 3,
     input_tokens: 0,
     output_tokens: 0,
+    usage_by_provider_model: [],
     served_provider_id: null,
     served_model: null,
     ...overrides,


### PR DESCRIPTION
## Summary

- add migration `0003_operator_run_token_usage` to retain per-run input/output token totals and provider/model attribution
- persist the final usage snapshot atomically with normal terminal transitions, including partial usage on failures and usage observed across cancellation/timeout races
- retain an authoritative `by_provider_model` breakdown so multi-call failover runs do not attribute all tokens to the last provider
- expose persisted usage on durable message-run responses and document the historical cost-analysis contract
- extend PostgreSQL schema verification and route coverage for successful, failed, duplicate, and mixed-provider durable runs

## Scope

This follows the maintainer direction on #349: it focuses on persisting the usage data the Operator already computes. It does not add Operator-specific labeled metrics, tracing, audit events, probes, or provisioning gauges.

## Validation

- 10 consecutive focused runs after review fixes: 1,820/1,820 tests passed with no flakes
- combined compatibility check with #345 and #347 after review fixes: 196/196 relevant tests passed after clean merges
- complete API suite: 77 files, 1,348 tests passed
- repository style, typecheck, lint (0 errors), and 325-page production docs build passed
- full migration validator passed on disposable PostgreSQL 18.4, including frozen-history, idempotency, concurrent-migrator, grants/RLS, and schema checks
- explicit `0003` apply/down/up round-trip passed: 5 usage columns and 3 active `NOT VALID` constraints verified; validation is intentionally deferred outside the migration transaction
- canonical `pnpm run ci` completed all TypeScript build/test stages; the local run then stopped at the Go stage because this environment has no `go` executable (`spawnSync go ENOENT`)

Closes #349