### PR TITLE
fix(operator): stop model work on cancelled runs

### DIFF
--- a/apps/api/src/operator-gateway.ts
+++ b/apps/api/src/operator-gateway.ts
@@ -47,6 +47,10 @@ export interface GatewayMessage {
 export interface CompletionOptions {
   maxTokens?: number
   temperature?: number
+  // An explicit caller cancellation signal. The provider call composes it with its own timeout,
+  // so cancelling a durable Operator run stops the in-flight transport while a timeout still
+  // follows the normal provider failover path.
+  signal?: AbortSignal
   // The id of the provider the caller would like to use first. When it is configured and
   // available it is tried ahead of the failover order; otherwise it is ignored and the
   // normal order applies, so a stale preference never disables the gateway.
@@ -338,6 +342,7 @@ async function callProvider(
 ): Promise<CompletionResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), provider.timeoutMs)
+  const signal = options.signal ? AbortSignal.any([controller.signal, options.signal]) : controller.signal
   try {
     const { system, conversation } = splitSystem(messages)
     const result = await generateText({
@@ -346,9 +351,10 @@ async function callProvider(
       messages: conversation,
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
-      abortSignal: controller.signal,
+      abortSignal: signal,
       maxRetries: 0,
     })
+    options.signal?.throwIfAborted()
     const text = result.text.trim()
     if (text.length === 0) throw new Error('provider returned an empty completion')
     const reasoning = result.reasoningText?.trim()
@@ -383,6 +389,7 @@ async function callProviderStream(
 ): Promise<CompletionResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), provider.timeoutMs)
+  const signal = options.signal ? AbortSignal.any([controller.signal, options.signal]) : controller.signal
   // Whether any delta has reached the client. Once it has, the partial answer is visible, so a
   // later failure ends the turn rather than failing over; before it has, the failure is invisible
   // and fails over cleanly.
@@ -395,7 +402,7 @@ async function callProviderStream(
       messages: conversation,
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
-      abortSignal: controller.signal,
+      abortSignal: signal,
       maxRetries: 0,
       // Azure delivers a completion in a few coarse chunks, so every token of a chunk lands in one
       // burst and a short answer arrives all at once. Re-pace the text channel word by word so the
@@ -419,6 +426,7 @@ async function callProviderStream(
         throw part.error
       }
     }
+    options.signal?.throwIfAborted()
     const text = (await result.text).trim()
     if (text.length === 0) throw new Error('provider returned an empty completion')
     const reasoning = (await result.reasoningText)?.trim()
@@ -457,6 +465,7 @@ async function callProviderObject<T>(
 ): Promise<CompletionObjectResult<T>> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), provider.timeoutMs)
+  const signal = options.signal ? AbortSignal.any([controller.signal, options.signal]) : controller.signal
   try {
     const { system, conversation } = splitSystem(messages)
     const result = await generateObject({
@@ -466,9 +475,10 @@ async function callProviderObject<T>(
       messages: conversation,
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
-      abortSignal: controller.signal,
+      abortSignal: signal,
       maxRetries: 0,
     })
+    options.signal?.throwIfAborted()
     return {
       value: result.object,
       provider: provider.id,
@@ -501,6 +511,7 @@ export interface Gateway {
 async function runWithFailover<T>(
   available: ProviderConfig[],
   preferredProvider: string | undefined,
+  signal: AbortSignal | undefined,
   call: (provider: ProviderConfig) => Promise<T>,
 ): Promise<T> {
   if (available.length === 0) throw new GatewayUnavailableError()
@@ -514,9 +525,13 @@ async function runWithFailover<T>(
   }
   const attempts: { provider: string; reason: string }[] = []
   for (const provider of order) {
+    signal?.throwIfAborted()
     try {
       return await call(provider)
     } catch (err) {
+      // Explicit run cancellation is authoritative and must never spend another provider call.
+      // The provider's private timeout signal is not this signal, so timeouts retain failover.
+      if (signal?.aborted) throw err
       // A stream that already reached the client cannot be retried on another provider without
       // corrupting the visible output, so this failure ends the turn instead of failing over.
       if (err instanceof GatewayStreamInterruptedError) throw err
@@ -554,19 +569,19 @@ export function createGateway(providers: ProviderConfig[], fetchImpl: FetchImpl 
     },
 
     complete(messages, options = {}) {
-      return runWithFailover(available, options.preferredProvider, (provider) =>
+      return runWithFailover(available, options.preferredProvider, options.signal, (provider) =>
         callProvider(fetchImpl, provider, messages, options, governanceMiddleware),
       )
     },
 
     completeObject(messages, schema, options = {}) {
-      return runWithFailover(available, options.preferredProvider, (provider) =>
+      return runWithFailover(available, options.preferredProvider, options.signal, (provider) =>
         callProviderObject(fetchImpl, provider, messages, schema, options, governanceMiddleware),
       )
     },
 
     stream(messages, handlers, options = {}) {
-      return runWithFailover(available, options.preferredProvider, (provider) =>
+      return runWithFailover(available, options.preferredProvider, options.signal, (provider) =>
         callProviderStream(fetchImpl, provider, messages, options, handlers, governanceMiddleware),
       )
     },
@@ -639,6 +654,19 @@ export function preferProvider(gateway: Gateway, providerId: string | null): Gat
     completeObject: (messages, schema, options = {}) =>
       gateway.completeObject(messages, schema, { ...options, preferredProvider: providerId }),
     stream: (messages, handlers, options = {}) => gateway.stream(messages, handlers, { ...options, preferredProvider: providerId }),
+  }
+}
+
+// Binds every model call made through a gateway to one durable run's cancellation signal without
+// teaching individual agents about HTTP or persistence. Call-specific generation settings still
+// pass through unchanged; the run signal is authoritative for the lifetime of this wrapper.
+export function withAbortSignal(gateway: Gateway, signal: AbortSignal): Gateway {
+  return {
+    status: () => gateway.status(),
+    active: () => gateway.active(),
+    complete: (messages, options = {}) => gateway.complete(messages, { ...options, signal }),
+    completeObject: (messages, schema, options = {}) => gateway.completeObject(messages, schema, { ...options, signal }),
+    stream: (messages, handlers, options = {}) => gateway.stream(messages, handlers, { ...options, signal }),
   }
 }
 

--- a/apps/api/src/operator-orchestrator.ts
+++ b/apps/api/src/operator-orchestrator.ts
@@ -30,7 +30,7 @@ import { CAPABILITIES, collectStepReferences, validateProposedPlan, type Propose
 import type { Researcher } from './operator-research.js'
 import type { Evidence } from './operator-research.js'
 import type { DocSnippet } from './operator-docs.js'
-import { streamingAnswers, type Gateway } from './operator-gateway.js'
+import { streamingAnswers, withAbortSignal, type Gateway } from './operator-gateway.js'
 
 // A skill is a capability the orchestrator can invoke, not a pipeline stage. answer skills
 // reply as text; plan skills produce a proposed plan the deterministic spine then governs. A
@@ -207,6 +207,27 @@ export interface HandleOptions {
   // authoritative result is unchanged whether or not anyone listens, and it is absent for models
   // that expose no reasoning. Omitted when the caller does not stream.
   onReasoningDelta?: (chunk: string) => void
+  // The durable message-run cancellation boundary. signal interrupts a provider call on the same
+  // API instance; isCancelled reads persisted state between stages so cancellation observed by a
+  // different instance still prevents every subsequent model call. Neither is tied to the client
+  // connection: disconnected runs intentionally continue in the background.
+  signal?: AbortSignal
+  isCancelled?: () => boolean | Promise<boolean>
+}
+
+// A deliberate stop raised only at an orchestration checkpoint. The route distinguishes it from
+// provider and governance failures and returns the already-settled durable cancellation unchanged.
+export class OrchestrationCancelledError extends Error {
+  constructor() {
+    super('operator message run cancelled')
+    this.name = 'OrchestrationCancelledError'
+  }
+}
+
+async function cancellationCheckpoint(options: HandleOptions): Promise<void> {
+  if (options.signal?.aborted) throw new OrchestrationCancelledError()
+  if (await options.isCancelled?.()) throw new OrchestrationCancelledError()
+  if (options.signal?.aborted) throw new OrchestrationCancelledError()
 }
 
 // The deterministic answer an ask-mode conversation returns for a request that would require a
@@ -294,7 +315,9 @@ async function deliberatePlan(
   context: AgentContext,
   skill: PlanSkill,
   emit: OnProgress,
+  checkpoint: () => Promise<void>,
 ): Promise<AgentResult<PlannerProposal>> {
+  await checkpoint()
   emit({ stage: 'planning' })
   const proposal = await skill.run(gateway, message, context)
   if (!proposal.ok || proposal.value.steps.length === 0) return proposal
@@ -306,6 +329,7 @@ async function deliberatePlan(
       priorSummary: candidate.value.summary,
       diagnostics: validation.diagnostics.map((d) => `${d.step_id}: ${d.message}`),
     }
+    await checkpoint()
     emit({ stage: 'repairing' })
     const repaired = await runPlanner(gateway, message, context, feedback)
     if (repaired.ok && validateProposedPlan(repaired.value).ok) candidate = repaired
@@ -322,6 +346,7 @@ async function deliberatePlan(
   // have none of. Every skipped plan is still fully governed by catalog validation, preview, the
   // guardian's review, and the approval gate, so skipping spends no safety, only a model call.
   if (!planIsCoupled(candidate.value)) return candidate
+  await checkpoint()
   emit({ stage: 'critiquing' })
   const critique = await runCritic(gateway, candidate.value, message, context)
   if (critique.ok && critique.value.verdict === 'revise' && critique.value.deficiencies.length > 0) {
@@ -329,6 +354,7 @@ async function deliberatePlan(
       priorSummary: candidate.value.summary,
       diagnostics: critique.value.deficiencies.map((d) => d.issue),
     }
+    await checkpoint()
     emit({ stage: 'revising' })
     const revised = await runPlanner(gateway, message, context, feedback)
     if (revised.ok && revised.value.steps.length > 0 && validateProposedPlan(revised.value).ok) return revised
@@ -347,8 +373,10 @@ async function groundAnswer(
   message: string,
   answer: AgentResult<{ text: string; reasoning?: string }>,
   context: AgentContext,
+  checkpoint: () => Promise<void>,
 ): Promise<AgentResult<{ text: string; reasoning?: string }>> {
   if (!answer.ok || !context.evidence || context.evidence.length === 0) return answer
+  await checkpoint()
   try {
     const check = await runAnswerCheck(gateway, message, answer.value.text, context)
     if (check.ok && !check.value.grounded && check.value.correction) {
@@ -356,6 +384,9 @@ async function groundAnswer(
     }
     return answer
   } catch {
+    // The grounding check otherwise fails open. Cancellation is not a grounding failure: it must
+    // escape so the route stops the durable run instead of accepting the ungrounded draft.
+    await checkpoint()
     return answer
   }
 }
@@ -379,8 +410,11 @@ export function createOrchestrator(registry: SkillRegistry = createSkillRegistry
     async handle(gateway, message, context, options = {}): Promise<OrchestrationResult> {
       const mode: OperatorMode = options.mode ?? 'agent'
       const emit: OnProgress = options.onProgress ?? (() => {})
+      const checkpoint = () => cancellationCheckpoint(options)
+      const runGateway = options.signal ? withAbortSignal(gateway, options.signal) : gateway
+      await checkpoint()
       emit({ stage: 'triaging' })
-      const triage = await runTriage(gateway, message, context)
+      const triage = await runTriage(runGateway, message, context)
       const classification: OperatorTriage = triage.ok ? triage.value : { tier: 'read', topic: 'general' }
       const tier = classification.tier
 
@@ -390,6 +424,7 @@ export function createOrchestrator(registry: SkillRegistry = createSkillRegistry
       // policy draft's whole purpose is a governed create the ask-mode write path would reject, so an
       // ask conversation must not surface that action at all. Conversational and read requests proceed.
       if (mode === 'ask' && (tierPlans(tier) || tierAuthorsPolicy(tier))) {
+        await checkpoint()
         return { tier, outcome: { kind: 'answer', result: { ok: true, value: { text: ASK_MODE_CHANGE_MESSAGE } } } }
       }
 
@@ -401,10 +436,12 @@ export function createOrchestrator(registry: SkillRegistry = createSkillRegistry
         // specialist authors and validates a draft; it applies nothing, and creating, versioning, or
         // activating any document still flows through the governed, approval-gated path the route
         // owns. The draft is returned as its own outcome the route persists and surfaces.
+        await checkpoint()
         emit({ stage: 'gathering' })
         const policyContext = withDocs(await withEvidence(context, options.researcher, classification.domains), message, options.docs)
+        await checkpoint()
         emit({ stage: 'authoring' })
-        const result = await skill.run(gateway, message, policyContext)
+        const result = await skill.run(runGateway, message, policyContext)
         return { tier, outcome: { kind: 'policy', result } }
       }
 
@@ -416,18 +453,20 @@ export function createOrchestrator(registry: SkillRegistry = createSkillRegistry
         // guardian review over any plan that proposes steps. The route still owns validate, preview,
         // approve, and apply; the guardian, the critic, and the repair pass only improve and inform
         // the proposal.
+        await checkpoint()
         emit({ stage: 'gathering' })
         let planContext = withDocs(await withEvidence(context, options.researcher, classification.domains), message, options.docs)
-        let result = await deliberatePlan(gateway, message, planContext, skill, emit)
+        let result = await deliberatePlan(runGateway, message, planContext, skill, emit, checkpoint)
         // The planner may decline to plan and instead name the object domains it must read before it
         // can propose responsibly. Caracal honors that exactly once: it reads those domains, merges
         // the fresh evidence into the context, and replans. The loop is bounded to a single expansion
         // so a turn can never fan out unboundedly, and the planner only directs what to read - Caracal
         // decides and still owns validate, preview, and approval of whatever plan results.
         if (result.ok && result.value.steps.length === 0 && result.value.needs && options.researcher) {
+          await checkpoint()
           emit({ stage: 'gathering' })
           planContext = await expandEvidence(planContext, options.researcher, result.value.needs.domains)
-          result = await deliberatePlan(gateway, message, planContext, skill, emit)
+          result = await deliberatePlan(runGateway, message, planContext, skill, emit, checkpoint)
         }
         // When the planner could not plan responsibly it proposes no steps and asks one clarifying
         // question instead of guessing. Caracal relays that question to the operator as an answer
@@ -443,17 +482,22 @@ export function createOrchestrator(registry: SkillRegistry = createSkillRegistry
         // synthesizes the guidance the question actually asked for - so a read-only plan never
         // surfaces as an approvable artifact.
         if (result.ok && result.value.steps.length > 0 && result.value.steps.every((s) => CAPABILITIES[s.capability]?.mutating === false)) {
+          await checkpoint()
           const readDomains = [...new Set(result.value.steps.map((s) => CAPABILITIES[s.capability].domain))]
           const readContext = await expandEvidence(planContext, options.researcher, readDomains)
+          await checkpoint()
           emit({ stage: 'answering' })
-          const readGateway = options.onAnswerDelta ? streamingAnswers(gateway, options.onAnswerDelta, options.onReasoningDelta) : gateway
+          const readGateway = options.onAnswerDelta
+            ? streamingAnswers(runGateway, options.onAnswerDelta, options.onReasoningDelta)
+            : runGateway
           const drafted = await answerSkillForTopic(classification.topic).run(readGateway, message, readContext)
-          const grounded = await groundAnswer(gateway, message, drafted, readContext)
+          const grounded = await groundAnswer(runGateway, message, drafted, readContext, checkpoint)
           return { tier, outcome: { kind: 'answer', result: grounded, evidence: readContext.evidence } }
         }
         if (result.ok && result.value.steps.length > 0) {
+          await checkpoint()
           emit({ stage: 'guarding' })
-          const reviewed = await runSecurityAnalyst(gateway, result.value, planContext)
+          const reviewed = await runSecurityAnalyst(runGateway, result.value, planContext)
           // The review state is explicit either way: a completed review attaches its advisory, and a
           // failed one attaches the precise reason, so the plan is never silently unreviewed. The
           // guidance is the guardian's concrete recommendation when it judged the plan risky or
@@ -472,17 +516,23 @@ export function createOrchestrator(registry: SkillRegistry = createSkillRegistry
       // conversational tier needs no state read and pays nothing. Both ground their answer in the
       // real documentation so exact names, endpoints, and fields come from the docs, not the model.
       const reads = tierReadsState(tier)
-      if (reads) emit({ stage: 'gathering' })
+      if (reads) {
+        await checkpoint()
+        emit({ stage: 'gathering' })
+      }
       const stateContext = reads ? await withEvidence(context, options.researcher, classification.domains) : context
       const answerContext = withDocs(stateContext, message, options.docs)
+      await checkpoint()
       emit({ stage: 'answering' })
       // Stream the answer's tokens and the model's reasoning to the caller when it is listening, so
       // the console renders the answer as it is produced and shows the thinking while it works.
       // Only the answer skill streams; grounding below still uses the unwrapped gateway, so its
       // structured check is unaffected.
-      const answerGateway = options.onAnswerDelta ? streamingAnswers(gateway, options.onAnswerDelta, options.onReasoningDelta) : gateway
+      const answerGateway = options.onAnswerDelta
+        ? streamingAnswers(runGateway, options.onAnswerDelta, options.onReasoningDelta)
+        : runGateway
       const answer = await skill.run(answerGateway, message, answerContext)
-      const result = await groundAnswer(gateway, message, answer, answerContext)
+      const result = await groundAnswer(runGateway, message, answer, answerContext, checkpoint)
       // The gathered evidence rides along with the grounded answer so the route can persist the
       // structured live-state views the answer was grounded in, not just its prose.
       return { tier, outcome: { kind: 'answer', result, evidence: stateContext.evidence } }

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -52,7 +52,13 @@ import {
 import { type GovernanceLimits } from '../operator-ai-governance.js'
 import { runVerifier, type AgentContext, type OperatorMode, type PolicyDraft } from '../operator-agents.js'
 import { recallConversationMemory, rememberAppliedChange } from '../operator-conversation-memory.js'
-import { createOrchestrator, type OnProgress, type PlanReview, type ProgressEvent } from '../operator-orchestrator.js'
+import {
+  createOrchestrator,
+  OrchestrationCancelledError,
+  type OnProgress,
+  type PlanReview,
+  type ProgressEvent,
+} from '../operator-orchestrator.js'
 import { createStateResearcher } from '../operator-research.js'
 import type { Evidence } from '../operator-research.js'
 import { retrieveDocs } from '../operator-docs.js'
@@ -780,6 +786,13 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
   // returning a typed artifact the deterministic spine below validates, previews, and governs.
   // Built once for the plugin; it holds no per-request state.
   const orchestrator = createOrchestrator()
+
+  // Active durable runs on this API instance. Persisted run state remains authoritative across
+  // replicas; this local index is only the fast path that lets the explicit cancel route abort a
+  // provider transport already running on the same instance. Entries live exactly as long as the
+  // orchestration call and are never tied to the SSE connection, so a disconnect still leaves the
+  // durable run working as designed.
+  const activeMessageRuns = new Map<string, AbortController>()
 
   // Builds the Operator's governed control client for the executor role identity scoped to the
   // zone the conversation acts in, or null when governed execution is not fully configured - no
@@ -2240,6 +2253,26 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       reply.raw.end()
     }
 
+    const activeRunId = messageRun?.id ?? null
+    const runController = activeRunId ? new AbortController() : null
+    if (activeRunId && runController) activeMessageRuns.set(activeRunId, runController)
+
+    // Poll the durable row only at bounded orchestration checkpoints. This is the cross-instance
+    // cancellation path: a cancel handled by another replica cannot reach the local controller,
+    // but its committed state is observed before the next stage spends another model call.
+    const isRunCancelled = async (): Promise<boolean> => {
+      if (!activeRunId) return false
+      if (runController?.signal.aborted) return true
+      const { rows } = await fastify.db.query<MessageRunRow>(
+        `SELECT ${MESSAGE_RUN_SELECT} FROM operator_message_runs WHERE id = $1 AND zone_id = $2`,
+        [activeRunId, params.zoneId],
+      )
+      if (rows[0]?.state !== 'cancelled') return false
+      messageRun = rows[0]
+      runController?.abort()
+      return true
+    }
+
     try {
       // For a read tier the orchestrator first gathers live state through governed reads, so the
       // answer is grounded in current state rather than the model's guess. The researcher is the
@@ -2272,6 +2305,8 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         // Forward each reasoning delta as a reasoning frame so the console shows the model's
         // thinking live while it works, rather than a blank wait before the answer begins.
         onReasoningDelta: wantsStream ? (chunk: string) => writeSseEvent(reply, 'reasoning', { text: chunk }) : undefined,
+        signal: runController?.signal,
+        isCancelled: activeRunId ? isRunCancelled : undefined,
       })
 
       // A cancel that landed while the turn deliberated wins: the run already settled as cancelled,
@@ -2279,8 +2314,8 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       // user turn stays in the ledger - it was recorded before the work began and really happened.
       if (messageRun) {
         const { rows: current } = await fastify.db.query<MessageRunRow>(
-          `SELECT ${MESSAGE_RUN_SELECT} FROM operator_message_runs WHERE id = $1`,
-          [messageRun.id],
+          `SELECT ${MESSAGE_RUN_SELECT} FROM operator_message_runs WHERE id = $1 AND zone_id = $2`,
+          [messageRun.id, params.zoneId],
         )
         if (current[0] && current[0].state === 'cancelled') {
           messageRun = current[0]
@@ -2597,6 +2632,20 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         { state: 'completed', reason: 'answer_recorded' },
       )
     } catch (err) {
+      // Explicit cancellation is not an AI failure. The cancel transaction settles the durable
+      // row first, then aborts the same-instance transport; a persisted checkpoint on another
+      // instance raises the same orchestration stop. Reload that authoritative row and return it
+      // without recording model output or overwriting cancellation with a failed state.
+      if ((runController?.signal.aborted || err instanceof OrchestrationCancelledError) && activeRunId) {
+        const { rows } = await fastify.db.query<MessageRunRow>(
+          `SELECT ${MESSAGE_RUN_SELECT} FROM operator_message_runs WHERE id = $1 AND zone_id = $2`,
+          [activeRunId, params.zoneId],
+        )
+        if (rows[0]?.state === 'cancelled') {
+          messageRun = rows[0]
+          return finish(200, { intent: 'cancelled', ok: false, error: 'run_cancelled', ...meta() })
+        }
+      }
       if (err instanceof GatewayUnavailableError)
         return finish(409, { error: 'ai_unavailable' }, { state: 'failed', reason: 'ai_unavailable', errorCode: 'ai_unavailable' })
       if (err instanceof GatewayBudgetError)
@@ -2641,6 +2690,10 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       }
       if (messageRun) return finish(500, { error: 'ai_failed' }, { state: 'failed', reason: 'ai_failed', errorCode: 'ai_failed' })
       throw err
+    } finally {
+      if (activeRunId && runController && activeMessageRuns.get(activeRunId) === runController) {
+        activeMessageRuns.delete(activeRunId)
+      }
     }
   })
 
@@ -2663,13 +2716,17 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
          FOR UPDATE`,
         [params.zoneId, params.id, parsed.data.client_message_id],
       )
-      if (!rows[0]) return { status: 404, body: { error: 'run_not_found' } }
+      if (!rows[0]) return { status: 404, body: { error: 'run_not_found' }, cancelledRunId: null }
       if (isTerminalMessageRunState(rows[0].state)) {
-        return { status: 409, body: { error: 'run_settled', message_run: publicMessageRun(rows[0]) } }
+        return { status: 409, body: { error: 'run_settled', message_run: publicMessageRun(rows[0]) }, cancelledRunId: null }
       }
       const run = await writeMessageRunEventLocked(client, { run: rows[0], state: 'cancelled', reason: 'operator_cancelled' })
-      return { status: 200, body: { ok: true, message_run: publicMessageRun(run) } }
+      return { status: 200, body: { ok: true, message_run: publicMessageRun(run) }, cancelledRunId: run.id }
     })
+    // Abort only after the transaction committed, so the message path always observes the
+    // authoritative cancelled row when its provider promise rejects. A run on another instance
+    // has no local entry and will stop at its next persisted checkpoint instead.
+    if (outcome.cancelledRunId) activeMessageRuns.get(outcome.cancelledRunId)?.abort()
     return reply.code(outcome.status).send(outcome.body)
   })
 }

--- a/tests/typescript/unit/api/operator-gateway.test.ts
+++ b/tests/typescript/unit/api/operator-gateway.test.ts
@@ -9,6 +9,7 @@ import {
   withUsage,
   preferProvider,
   streamingAnswers,
+  withAbortSignal,
   GatewayUnavailableError,
   GatewayError,
   GatewayBudgetError,
@@ -167,6 +168,23 @@ describe('gateway complete', () => {
     const gateway = createGateway([provider({ id: 'slow', timeoutMs: 10 }), provider({ id: 'fast' })], fetchMock as unknown as typeof fetch)
     const result = await gateway.complete([{ role: 'user', content: 'ping' }])
     expect(result.provider).toBe('fast')
+  })
+
+  it('aborts an explicit cancellation without failing over to another provider', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new DOMException('cancelled', 'AbortError')), { once: true })
+            controller.abort()
+          }),
+      )
+      .mockResolvedValueOnce(chatResponse('must not run'))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    await expect(gateway.complete([{ role: 'user', content: 'ping' }], { signal: controller.signal })).rejects.toThrow()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -391,6 +409,25 @@ describe('gateway completeObject', () => {
     expect(result.provider).toBe('second')
     expect(usage()).toMatchObject({ inputTokens: 10, outputTokens: 4 })
   })
+
+  it('aborts a structured completion without failing over to another provider', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new DOMException('cancelled', 'AbortError')), { once: true })
+            controller.abort()
+          }),
+      )
+      .mockResolvedValueOnce(objectResponse(validPlan))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    await expect(
+      gateway.completeObject([{ role: 'user', content: 'connect' }], ProposedPlan, { signal: controller.signal }),
+    ).rejects.toThrow()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('gateway stream', () => {
@@ -472,6 +509,42 @@ describe('gateway stream', () => {
     expect(result.provider).toBe('secondary')
     expect(deltas.join('')).toBe('recovered')
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts an explicit stream cancellation without failing over', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new DOMException('cancelled', 'AbortError')), { once: true })
+            controller.abort()
+          }),
+      )
+      .mockResolvedValueOnce(streamResponse(['must not run']))
+    const gateway = createGateway([provider({ id: 'primary' }), provider({ id: 'secondary' })], fetchMock as unknown as typeof fetch)
+    await expect(gateway.stream([{ role: 'user', content: 'hi' }], { onText: () => {} }, { signal: controller.signal })).rejects.toThrow()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('withAbortSignal', () => {
+  it('binds the same run signal to text, object, and streaming calls', async () => {
+    const signal = new AbortController().signal
+    const complete = vi.fn().mockResolvedValue({ text: 'ok', provider: 'p', model: 'm' })
+    const completeObject = vi.fn().mockResolvedValue({ value: {}, provider: 'p', model: 'm' })
+    const stream = vi.fn().mockResolvedValue({ text: 'ok', provider: 'p', model: 'm' })
+    const gateway = { status: vi.fn(), active: vi.fn(), complete, completeObject, stream } as unknown as Gateway
+    const bound = withAbortSignal(gateway, signal)
+
+    await bound.complete([], { maxTokens: 1 })
+    await bound.completeObject([], ProposedPlan, { temperature: 0 })
+    await bound.stream([], { onText: () => {} })
+
+    expect(complete).toHaveBeenCalledWith([], { maxTokens: 1, signal })
+    expect(completeObject).toHaveBeenCalledWith([], ProposedPlan, { temperature: 0, signal })
+    expect(stream).toHaveBeenCalledWith([], { onText: expect.any(Function) }, { signal })
   })
 })
 

--- a/tests/typescript/unit/api/operator-orchestrator.test.ts
+++ b/tests/typescript/unit/api/operator-orchestrator.test.ts
@@ -8,6 +8,7 @@ import {
   createSkillRegistry,
   createOrchestrator,
   ASK_MODE_CHANGE_MESSAGE,
+  OrchestrationCancelledError,
   type SkillRegistry,
   type Skill,
 } from '../../../../apps/api/src/operator-orchestrator.js'
@@ -109,6 +110,53 @@ describe('createSkillRegistry', () => {
 })
 
 describe('createOrchestrator', () => {
+  it('stops before the next model stage when persisted run state is cancelled', async () => {
+    const gateway = gatewayFor('conversational')
+    const isCancelled = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    await expect(createOrchestrator().handle(gateway, 'hello', emptyContext, { isCancelled })).rejects.toBeInstanceOf(
+      OrchestrationCancelledError,
+    )
+    expect(gateway.completeObject).toHaveBeenCalledTimes(1)
+    expect(gateway.complete).not.toHaveBeenCalled()
+  })
+
+  it('stops a plan after planning when cancellation lands before guardian review', async () => {
+    const plan = {
+      summary: 'Connect GitHub',
+      steps: [{ id: 's1', capability: 'connectProvider', args: { name: 'GitHub', kind: 'api_key' } }],
+    }
+    const gateway = planningGateway('change', plan)
+    const isCancelled = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+
+    await expect(createOrchestrator().handle(gateway, 'connect github', emptyContext, { isCancelled })).rejects.toBeInstanceOf(
+      OrchestrationCancelledError,
+    )
+    // Triage and planning ran; the security guardian was never dispatched.
+    expect(gateway.completeObject).toHaveBeenCalledTimes(2)
+  })
+
+  it('binds the run signal to an in-flight model stage', async () => {
+    const controller = new AbortController()
+    const completeObject = vi.fn(
+      (_messages: unknown, _schema: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          expect(options?.signal).toBe(controller.signal)
+          options?.signal?.addEventListener('abort', () => reject(new DOMException('cancelled', 'AbortError')), { once: true })
+        }),
+    )
+    const gateway = { status: () => ({ enabled: true, providers: [] }), completeObject } as unknown as Gateway
+    const handling = createOrchestrator().handle(gateway, 'hello', emptyContext, { signal: controller.signal })
+    await vi.waitFor(() => expect(completeObject).toHaveBeenCalledTimes(1))
+    controller.abort()
+    await expect(handling).rejects.toThrow()
+  })
+
   it('answers a read tier with the answer skill', async () => {
     const result = await createOrchestrator().handle(gatewayFor('read', 'because the scope is missing'), 'why denied', emptyContext)
     expect(result.tier).toBe('read')

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -2363,6 +2363,124 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/message', () => {
     expect(messageInsert![1][8]).toBe('msg-2')
   })
 
+  it('aborts the in-flight provider on explicit cancel and persists no model output', async () => {
+    let providerStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      providerStarted = resolve
+    })
+    let providerAborted = false
+    const fetchImpl = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          providerStarted()
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              providerAborted = true
+              reject(new DOMException('cancelled', 'AbortError'))
+            },
+            { once: true },
+          )
+        }),
+    ) as unknown as typeof fetch
+    const { app, clientQuery, db } = buildApp(true, { aiProviders: [provider], fetchImpl })
+
+    let created = false
+    let runId = 'run-unset'
+    let state = 'queued'
+    let reason: string | null = null
+    let serverTurnId: string | null = null
+    let lastEventSeq = 0
+    const run = () => ({
+      id: runId,
+      zone_id: 'z1',
+      conversation_id: 'conv-1',
+      client_message_id: 'msg-cancel',
+      server_message_turn_id: serverTurnId,
+      correlation_id: 'corr-cancel',
+      state,
+      actor_id: 'actor-1',
+      provider_id: 'primary',
+      reason,
+      error_code: null,
+      error_detail: null,
+      deadline_at: '2026-07-01T00:02:00Z',
+      started_at: '2026-07-01T00:00:00Z',
+      updated_at: '2026-07-01T00:00:01Z',
+      completed_at: state === 'cancelled' ? '2026-07-01T00:00:02Z' : null,
+      last_event_seq: lastEventSeq,
+    })
+
+    clientQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM operator_conversations') && sql.includes('FOR UPDATE')) {
+        return { rows: [{ status: 'active', mode: 'agent', autopilot: false, next_seq: 1 }] }
+      }
+      if (sql.includes('WHERE zone_id = $1 AND conversation_id = $2 AND client_message_id = $3')) {
+        return { rows: created ? [run()] : [] }
+      }
+      if (sql.includes('WHERE conversation_id = $1 AND client_message_id = $2')) return { rows: [] }
+      if (sql.startsWith('INSERT INTO operator_message_runs')) {
+        created = true
+        runId = String(params?.[0])
+        return { rows: [run()] }
+      }
+      if (sql.startsWith('INSERT INTO operator_message_run_events')) return { rows: [] }
+      if (sql.startsWith('UPDATE operator_message_runs') && sql.includes('SET state = $2')) {
+        state = String(params?.[1])
+        reason = typeof params?.[2] === 'string' ? params[2] : reason
+        lastEventSeq = Number(params?.[6])
+        return { rows: [run()] }
+      }
+      if (sql.startsWith('UPDATE operator_message_runs') && sql.includes('SET server_message_turn_id = $2')) {
+        serverTurnId = String(params?.[1])
+        return { rows: [run()] }
+      }
+      if (sql.includes('FROM operator_message_runs') && sql.includes('WHERE id = $1 FOR UPDATE')) return { rows: [run()] }
+      if (sql.startsWith('INSERT INTO operator_turns')) return { rows: [{ id: 'turn-user', seq: 1, kind: 'message' }] }
+      return { rows: [], rowCount: 1 }
+    })
+    db.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM operator_message_runs') && sql.includes('WHERE id = $1 AND zone_id = $2')) return { rows: [run()] }
+      if (sql.includes('FROM zones')) return { rows: [{ name: 'Pied Piper Production', slug: 'z1', operator_governed: false }] }
+      return { rows: [] }
+    })
+
+    await app.ready()
+    const messageResponse = app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/message',
+      payload: {
+        message: 'why was this denied',
+        client_message_id: 'msg-cancel',
+        correlation_id: 'corr-cancel',
+        provider: 'primary',
+      },
+    })
+    await started
+
+    const cancelResponse = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/message-runs/cancel',
+      payload: { client_message_id: 'msg-cancel' },
+    })
+    const messageResult = await messageResponse
+
+    expect(cancelResponse.statusCode).toBe(200)
+    expect(cancelResponse.json()).toMatchObject({ ok: true, message_run: { state: 'cancelled' } })
+    expect(providerAborted).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(messageResult.statusCode).toBe(200)
+    expect(messageResult.json()).toMatchObject({
+      intent: 'cancelled',
+      ok: false,
+      error: 'run_cancelled',
+      message_run: { state: 'cancelled', reason: 'operator_cancelled' },
+    })
+    // The user message remains in the ledger, but no operator note or plan is persisted after the
+    // cancellation wins the race.
+    expect(clientQuery.mock.calls.filter((call) => String(call[0]).startsWith('INSERT INTO operator_turns'))).toHaveLength(1)
+  })
+
   it('refuses a message in a system zone', async () => {
     const { app } = buildApp(true, { aiProviders: [provider], systemZones: ['z1'] })
     await app.ready()


### PR DESCRIPTION
## Summary

- check the authoritative persisted message-run state between orchestration stages, stopping before another model call after cancellation
- keep SSE disconnect behavior unchanged so durable runs still finish when a client leaves
- register active durable runs per API instance so the cancel route can abort an in-flight provider transport after the cancellation transaction commits
- compose explicit cancellation with each provider timeout and prevent cancellation from spending the failover chain
- preserve cancellation as the terminal run state and persist no model-produced output after it wins

## Scope

This follows the maintainer direction on #350: persisted cancellation drives orchestration, same-instance abort is a fast path, and client disconnect is deliberately not a cancellation signal.

Closes #350

## Testing

- affected gateway/orchestrator/route slice: 240 tests, 10 consecutive passes (2,400 executions)
- post-rebase affected slice: 240 tests passed
- full API suite: 77 files, 1,355 tests passed
- all 18 TypeScript package test suites passed
- API TypeScript build passed
- repository style passed
- repository lint passed (zero errors; existing web warnings only)
- repository typecheck passed
- `git diff --check` passed

## Behavioral guarantees

- explicit cancel aborts text, structured, and streaming provider calls on the same instance
- explicit cancel never fails over to another provider
- provider timeout still follows normal failover behavior
- a cancel handled by another instance is observed at the next persisted orchestration checkpoint
- a disconnected SSE client does not abort the run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cancellation support for operator message runs, including in-flight provider requests.
  * Cancellation state is preserved across processing stages and instances.
  * Cancelled runs return their run ID and avoid saving model output or assistant responses.
  * Provider failover stops when a caller cancels a request, while timeouts can still trigger failover.

* **Bug Fixes**
  * Prevented cancelled operations from continuing or persisting partial results.

* **Tests**
  * Added coverage for cancellation across text, structured, streaming, orchestration, and message-run workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->