### PR TITLE
test(api): cover governed Operator boot wiring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -532,6 +532,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      # The boot-level API integration imports the Engine through buildApp(). The embedded
+      # runtime asset is generated (and intentionally gitignored), so a clean PostgreSQL job
+      # must create it just like the TypeScript build job does.
+      - name: Generate Engine embedded runtime asset
+        run: pnpm --filter @caracalai/engine sync-embedded
+
       - name: Apply migrations for integration tests
         env:
           MIGRATIONS_DIR: ${{ github.workspace }}/infra/postgres/migrations

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,8 +166,11 @@ jobs:
                   docs=true
                   ;;
               esac
+              # The PostgreSQL job also runs the boot-level API integration tests, which
+              # exercise apps/api and its TypeScript workspace dependencies, so those
+              # paths must trigger it alongside the migrations themselves.
               case "$path" in
-                .github/workflows/test.yml|infra/postgres/**)
+                .github/workflows/test.yml|infra/postgres/**|apps/api/**|packages/engine/**|packages/*/ts/**|packages/adapters/*/ts/**|packages/backends/*/ts/**|tests/typescript/integration/**|tests/shared/test-utils/typescript/**|package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
                   postgres=true
                   ;;
               esac

--- a/tests/shared/test-utils/typescript/governed-operator-harness.ts
+++ b/tests/shared/test-utils/typescript/governed-operator-harness.ts
@@ -1,0 +1,346 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Shared boot-level harness for governed Operator integration tests. It keeps the API and
+// Postgres real while replacing only the separately deployed STS, Coordinator, Gateway, and
+// model upstream with small HTTP protocol fakes. Full-lifecycle tests can reuse the same boot
+// boundary without copying the system-zone provisioning setup.
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { once } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import type { FastifyInstance } from 'fastify'
+import type pg from 'pg'
+import { buildApp } from '../../../../apps/api/src/app.js'
+import { seedBootstrapAdminToken } from '../../../../apps/api/src/auth.js'
+import type { Config } from '../../../../apps/api/src/config.js'
+import { newDB, scopedDB } from '../../../../apps/api/src/db.js'
+import type { RedisClient } from '../../../../apps/api/src/redis.js'
+import { llmResourceIdentifier } from '../../../../apps/api/src/system-zone.js'
+
+const PROVIDER_ID = 'boot-e2e'
+const MODEL = 'operator-test-model'
+const UPSTREAM_KEY = 'upstream-key-must-stay-sealed'
+const ADMIN_TOKEN = 'governed-operator-boot-admin-token'
+
+interface HttpFixture {
+  url: string
+  close: () => Promise<void>
+}
+
+export interface GovernedGatewayCall {
+  authorization: string | null
+  resource: string | null
+  baggage: string | null
+  path: string
+  body: string
+}
+
+export interface GovernedUpstreamCall {
+  authorization: string | null
+  path: string
+  body: string
+}
+
+export interface StsExchange {
+  scope: string
+  zoneId: string | null
+  applicationId: string | null
+}
+
+export interface GovernedOperatorHarness {
+  app: FastifyInstance
+  apiUrl: string
+  adminToken: string
+  pool: pg.Pool
+  providerId: string
+  model: string
+  resourceIdentifier: string
+  stsScopes: string[]
+  stsExchanges: StsExchange[]
+  gatewayCalls: GovernedGatewayCall[]
+  upstreamCalls: GovernedUpstreamCall[]
+  close: () => Promise<void>
+}
+
+function json(reply: ServerResponse, status: number, body: unknown): void {
+  reply.writeHead(status, { 'content-type': 'application/json' })
+  reply.end(JSON.stringify(body))
+}
+
+async function requestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function startHttpFixture(handler: (request: IncomingMessage, reply: ServerResponse) => void | Promise<void>): Promise<HttpFixture> {
+  const server = createServer((request, reply) => {
+    void Promise.resolve(handler(request, reply)).catch((error: unknown) => {
+      if (reply.headersSent) {
+        reply.destroy(error instanceof Error ? error : new Error(String(error)))
+        return
+      }
+      json(reply, 500, { error: error instanceof Error ? error.message : String(error) })
+    })
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const address = server.address() as AddressInfo
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      server.close()
+      await once(server, 'close')
+    },
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const fixture = await startHttpFixture((_request, reply) => reply.end())
+  const port = Number(new URL(fixture.url).port)
+  await fixture.close()
+  return port
+}
+
+async function waitForGovernedExecution(apiUrl: string): Promise<void> {
+  const deadline = Date.now() + 30_000
+  let lastBody = ''
+  while (Date.now() < deadline) {
+    const response = await fetch(`${apiUrl}/v1/operator/status`, {
+      headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+    })
+    lastBody = await response.text()
+    if (response.ok) {
+      const status = JSON.parse(lastBody) as { governed_execution?: { configured?: boolean } }
+      if (status.governed_execution?.configured === true) return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`governed Operator did not finish boot provisioning: ${lastBody}`)
+}
+
+function makeRedis(): RedisClient {
+  const values = new Map<string, string>()
+  const counters = new Map<string, number>()
+  return {
+    incr: async (key: string) => {
+      const value = (counters.get(key) ?? 0) + 1
+      counters.set(key, value)
+      return value
+    },
+    expire: async () => 1,
+    set: async (key: string, value: string) => {
+      values.set(key, value)
+      return 'OK'
+    },
+    get: async (key: string) => values.get(key) ?? null,
+    del: async (key: string) => (values.delete(key) ? 1 : 0),
+    ping: async () => 'PONG',
+    eval: async () => 0,
+  } as unknown as RedisClient
+}
+
+function makeConfig(
+  databaseUrl: string,
+  apiUrl: string,
+  services: { sts: string; coordinator: string; gateway: string; upstream: string },
+): Config {
+  return {
+    port: Number(new URL(apiUrl).port),
+    host: '127.0.0.1',
+    databaseUrl,
+    redisUrl: 'redis://unused.test',
+    stsUrl: services.sts,
+    gatewayUrl: services.gateway,
+    coordinatorUrl: services.coordinator,
+    gatewayStsHmacKey: null,
+    auditHmacKey: null,
+    logLevel: process.env.CARACAL_TEST_LOG_LEVEL ?? 'fatal',
+    bootstrapAdminToken: ADMIN_TOKEN,
+    shutdownGraceMs: 5_000,
+    workerId: 'operator-governed-boot-e2e',
+    bodyLimitBytes: 1_048_576,
+    requestTimeoutMs: 30_000,
+    keepAliveTimeoutMs: 75_000,
+    auditRetentionMaxDays: 365,
+    stsMintRateLimitPerMin: 1_000,
+    db: {
+      poolMax: 8,
+      statementTimeoutMs: 15_000,
+      idleInTxTimeoutMs: 30_000,
+      connectionTimeoutMs: 5_000,
+      idleTimeoutMs: 5_000,
+    },
+    outbox: { pollIntervalMs: 100, batchSize: 8, lockDurationSec: 30, maxAttempts: 5, streamMaxLen: 1_000 },
+    readyRateLimitPerMin: 0,
+    v1RateLimitPerMin: 0,
+    adminAuthFailLimitPerMin: 0,
+    lastUsedDebounceSec: 0,
+    maxResourcesPerZone: 100_000,
+    readyOutboxDeadMax: 0,
+    trustProxy: false,
+    enableDocs: false,
+    operatorEnabled: true,
+    operatorAllowedCapabilities: null,
+    operatorSystemZones: [],
+    operatorAiProviders: [
+      {
+        id: PROVIDER_ID,
+        baseUrl: `${services.upstream}/v1`,
+        model: MODEL,
+        apiKey: UPSTREAM_KEY,
+        timeoutMs: 5_000,
+        contextWindow: 8_192,
+      },
+    ],
+    operatorAutopilotEnabled: false,
+    operatorAutopilotWriteBudget: 0,
+    operatorAiMaxOutputTokens: 4_096,
+    operatorAiMaxCallsPerTurn: 12,
+    metricsBearer: null,
+    control: {
+      jwksUrl: `${services.sts}/.well-known/jwks.json`,
+      issuer: services.sts,
+      audience: 'caracal-control',
+      apiUrl,
+      apiToken: ADMIN_TOKEN,
+      rateCapacity: 60,
+      rateWindowSec: 60,
+      ipRateLimitPerMin: 0,
+      replayTtlSec: 3_600,
+      gateFile: undefined,
+    },
+  }
+}
+
+export async function startGovernedOperatorHarness(databaseUrl: string): Promise<GovernedOperatorHarness> {
+  const fixtures: HttpFixture[] = []
+  let app: FastifyInstance | undefined
+  let pool: pg.Pool | undefined
+  const stsScopes: string[] = []
+  const stsExchanges: StsExchange[] = []
+  const gatewayCalls: GovernedGatewayCall[] = []
+  const upstreamCalls: GovernedUpstreamCall[] = []
+  let session = 0
+  let mandate = 0
+
+  try {
+    const upstream = await startHttpFixture(async (request, reply) => {
+      const body = await requestBody(request)
+      upstreamCalls.push({ authorization: request.headers.authorization ?? null, path: request.url ?? '', body })
+      json(reply, 200, {
+        id: 'chatcmpl-operator-boot',
+        object: 'chat.completion',
+        created: 1,
+        model: MODEL,
+        choices: [{ index: 0, message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+      })
+    })
+    fixtures.push(upstream)
+
+    const authority = await startHttpFixture(async (request, reply) => {
+      const method = request.method ?? 'GET'
+      const path = request.url ?? ''
+      const body = await requestBody(request)
+      if (method === 'POST' && path === '/oauth/2/token') {
+        const form = new URLSearchParams(body)
+        const scope = form.get('scope') ?? ''
+        stsScopes.push(scope)
+        stsExchanges.push({ scope, zoneId: form.get('zone_id'), applicationId: form.get('application_id') })
+        if (!form.get('client_secret')?.startsWith('cs_')) {
+          return json(reply, 401, { error: 'invalid_client' })
+        }
+        if (scope === 'agent:lifecycle') {
+          return json(reply, 200, { access_token: 'operator-lifecycle-token', token_type: 'Bearer', expires_in: 900 })
+        }
+        mandate += 1
+        return json(reply, 200, { access_token: `operator-mandate-${mandate}`, token_type: 'Bearer', expires_in: 900 })
+      }
+      if (method === 'POST' && path.endsWith('/agents')) {
+        session += 1
+        return json(reply, 200, { agent_session_id: `operator-session-${session}` })
+      }
+      if (method === 'POST' && path.endsWith('/delegations')) {
+        return json(reply, 200, { delegation_edge_id: 'operator-delegation-1' })
+      }
+      if (method === 'DELETE' && path.includes('/agents/')) {
+        reply.writeHead(204)
+        return reply.end()
+      }
+      if (method === 'GET' && path === '/.well-known/jwks.json') return json(reply, 200, { keys: [] })
+      return json(reply, 404, { error: `unexpected authority request: ${method} ${path}` })
+    })
+    fixtures.push(authority)
+
+    const gateway = await startHttpFixture(async (request, reply) => {
+      const body = await requestBody(request)
+      gatewayCalls.push({
+        authorization: request.headers.authorization ?? null,
+        resource: typeof request.headers['x-caracal-resource'] === 'string' ? request.headers['x-caracal-resource'] : null,
+        baggage: typeof request.headers.baggage === 'string' ? request.headers.baggage : null,
+        path: request.url ?? '',
+        body,
+      })
+      if (request.method !== 'POST' || request.url !== '/chat/completions') {
+        return json(reply, 404, { error: `unexpected gateway request: ${request.method} ${request.url}` })
+      }
+      const forwarded = await fetch(`${upstream.url}/v1/chat/completions`, {
+        method: request.method,
+        headers: { 'content-type': request.headers['content-type'] ?? 'application/json', authorization: `Bearer ${UPSTREAM_KEY}` },
+        body,
+      })
+      reply.writeHead(forwarded.status, { 'content-type': forwarded.headers.get('content-type') ?? 'application/json' })
+      reply.end(Buffer.from(await forwarded.arrayBuffer()))
+    })
+    fixtures.push(gateway)
+
+    const apiPort = await reservePort()
+    const apiUrl = `http://127.0.0.1:${apiPort}`
+    const cfg = makeConfig(databaseUrl, apiUrl, {
+      sts: authority.url,
+      coordinator: authority.url,
+      gateway: gateway.url,
+      upstream: upstream.url,
+    })
+    pool = newDB({
+      connectionString: databaseUrl,
+      max: cfg.db.poolMax,
+      statementTimeoutMs: cfg.db.statementTimeoutMs,
+      idleInTxTimeoutMs: cfg.db.idleInTxTimeoutMs,
+      connectionTimeoutMs: cfg.db.connectionTimeoutMs,
+      idleTimeoutMs: cfg.db.idleTimeoutMs,
+      applicationName: cfg.workerId,
+    })
+    const db = scopedDB(pool)
+    await seedBootstrapAdminToken(db, { envToken: ADMIN_TOKEN, log: () => {} })
+    app = await buildApp({ cfg, db, redis: makeRedis() })
+    await app.listen({ host: cfg.host, port: cfg.port })
+    await waitForGovernedExecution(apiUrl)
+
+    return {
+      app,
+      apiUrl,
+      adminToken: ADMIN_TOKEN,
+      pool,
+      providerId: PROVIDER_ID,
+      model: MODEL,
+      resourceIdentifier: llmResourceIdentifier(PROVIDER_ID),
+      stsScopes,
+      stsExchanges,
+      gatewayCalls,
+      upstreamCalls,
+      close: async () => {
+        await app?.close()
+        await pool?.end()
+        for (const fixture of fixtures.reverse()) await fixture.close()
+      },
+    }
+  } catch (error) {
+    await app?.close().catch(() => {})
+    await pool?.end().catch(() => {})
+    for (const fixture of fixtures.reverse()) await fixture.close().catch(() => {})
+    throw error
+  }
+}

--- a/tests/shared/test-utils/typescript/governed-operator-harness.ts
+++ b/tests/shared/test-utils/typescript/governed-operator-harness.ts
@@ -55,7 +55,9 @@ export interface GovernedOperatorHarness {
   pool: pg.Pool
   providerId: string
   model: string
+  upstreamKey: string
   resourceIdentifier: string
+  sessionIds: string[]
   stsScopes: string[]
   stsExchanges: StsExchange[]
   gatewayCalls: GovernedGatewayCall[]
@@ -87,20 +89,32 @@ async function startHttpFixture(handler: (request: IncomingMessage, reply: Serve
   server.listen(0, '127.0.0.1')
   await once(server, 'listening')
   const address = server.address() as AddressInfo
+  let closing: Promise<void> | undefined
   return {
     url: `http://127.0.0.1:${address.port}`,
-    close: async () => {
-      server.close()
-      await once(server, 'close')
+    close: () => {
+      if (!closing) {
+        closing = new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()))
+          server.closeAllConnections()
+        })
+      }
+      return closing
     },
   }
 }
 
-async function reservePort(): Promise<number> {
-  const fixture = await startHttpFixture((_request, reply) => reply.end())
-  const port = Number(new URL(fixture.url).port)
-  await fixture.close()
-  return port
+function copyRequestHeaders(request: IncomingMessage): Headers {
+  const headers = new Headers()
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (name === 'host' || name === 'connection' || name === 'content-length' || name === 'transfer-encoding') continue
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item)
+    } else if (value !== undefined) {
+      headers.set(name, value)
+    }
+  }
+  return headers
 }
 
 async function waitForGovernedExecution(apiUrl: string): Promise<void> {
@@ -143,11 +157,10 @@ function makeRedis(): RedisClient {
 
 function makeConfig(
   databaseUrl: string,
-  apiUrl: string,
-  services: { sts: string; coordinator: string; gateway: string; upstream: string },
+  services: { sts: string; coordinator: string; gateway: string; upstream: string; api: string },
 ): Config {
   return {
-    port: Number(new URL(apiUrl).port),
+    port: 0,
     host: '127.0.0.1',
     databaseUrl,
     redisUrl: 'redis://unused.test',
@@ -203,7 +216,7 @@ function makeConfig(
       jwksUrl: `${services.sts}/.well-known/jwks.json`,
       issuer: services.sts,
       audience: 'caracal-control',
-      apiUrl,
+      apiUrl: services.api,
       apiToken: ADMIN_TOKEN,
       rateCapacity: 60,
       rateWindowSec: 60,
@@ -222,8 +235,31 @@ export async function startGovernedOperatorHarness(databaseUrl: string): Promise
   const stsExchanges: StsExchange[] = []
   const gatewayCalls: GovernedGatewayCall[] = []
   const upstreamCalls: GovernedUpstreamCall[] = []
+  const sessionIds: string[] = []
   let session = 0
   let mandate = 0
+  let closing: Promise<void> | undefined
+  const close = (): Promise<void> => {
+    if (!closing) {
+      closing = (async () => {
+        const errors: unknown[] = []
+        const attempt = async (operation: () => Promise<unknown>): Promise<void> => {
+          try {
+            await operation()
+          } catch (error) {
+            errors.push(error)
+          }
+        }
+        const activeApp = app
+        const activePool = pool
+        if (activeApp) await attempt(() => activeApp.close())
+        if (activePool) await attempt(() => activePool.end())
+        for (const fixture of [...fixtures].reverse()) await attempt(fixture.close)
+        if (errors.length) throw new AggregateError(errors, 'governed Operator harness teardown failed')
+      })()
+    }
+    return closing
+  }
 
   try {
     const upstream = await startHttpFixture(async (request, reply) => {
@@ -260,7 +296,9 @@ export async function startGovernedOperatorHarness(databaseUrl: string): Promise
       }
       if (method === 'POST' && path.endsWith('/agents')) {
         session += 1
-        return json(reply, 200, { agent_session_id: `operator-session-${session}` })
+        const sessionId = `operator-session-${session}`
+        sessionIds.push(sessionId)
+        return json(reply, 200, { agent_session_id: sessionId })
       }
       if (method === 'POST' && path.endsWith('/delegations')) {
         return json(reply, 200, { delegation_edge_id: 'operator-delegation-1' })
@@ -296,13 +334,35 @@ export async function startGovernedOperatorHarness(databaseUrl: string): Promise
     })
     fixtures.push(gateway)
 
-    const apiPort = await reservePort()
-    const apiUrl = `http://127.0.0.1:${apiPort}`
-    const cfg = makeConfig(databaseUrl, apiUrl, {
+    // buildApp constructs its provisioning AdminClient before listen(), but Fastify's actual
+    // ephemeral port is known only after listen begins. A pre-bound proxy gives the client a
+    // stable URL and resolves the live Fastify port when provisioning makes its first request,
+    // eliminating the release-and-rebind race of reserving a port ahead of time.
+    const controlApi = await startHttpFixture(async (request, reply) => {
+      const address = app?.server.address()
+      if (!address || typeof address === 'string') return json(reply, 503, { error: 'api_not_listening' })
+      const body = await requestBody(request)
+      const response = await fetch(`http://127.0.0.1:${address.port}${request.url ?? '/'}`, {
+        method: request.method,
+        headers: copyRequestHeaders(request),
+        body: request.method === 'GET' || request.method === 'HEAD' ? undefined : body,
+        redirect: 'manual',
+      })
+      const responseHeaders: Record<string, string> = {}
+      response.headers.forEach((value, name) => {
+        responseHeaders[name] = value
+      })
+      reply.writeHead(response.status, responseHeaders)
+      reply.end(Buffer.from(await response.arrayBuffer()))
+    })
+    fixtures.push(controlApi)
+
+    const cfg = makeConfig(databaseUrl, {
       sts: authority.url,
       coordinator: authority.url,
       gateway: gateway.url,
       upstream: upstream.url,
+      api: controlApi.url,
     })
     pool = newDB({
       connectionString: databaseUrl,
@@ -316,7 +376,7 @@ export async function startGovernedOperatorHarness(databaseUrl: string): Promise
     const db = scopedDB(pool)
     await seedBootstrapAdminToken(db, { envToken: ADMIN_TOKEN, log: () => {} })
     app = await buildApp({ cfg, db, redis: makeRedis() })
-    await app.listen({ host: cfg.host, port: cfg.port })
+    const apiUrl = await app.listen({ host: cfg.host, port: cfg.port })
     await waitForGovernedExecution(apiUrl)
 
     return {
@@ -326,21 +386,17 @@ export async function startGovernedOperatorHarness(databaseUrl: string): Promise
       pool,
       providerId: PROVIDER_ID,
       model: MODEL,
+      upstreamKey: UPSTREAM_KEY,
       resourceIdentifier: llmResourceIdentifier(PROVIDER_ID),
+      sessionIds,
       stsScopes,
       stsExchanges,
       gatewayCalls,
       upstreamCalls,
-      close: async () => {
-        await app?.close()
-        await pool?.end()
-        for (const fixture of fixtures.reverse()) await fixture.close()
-      },
+      close,
     }
   } catch (error) {
-    await app?.close().catch(() => {})
-    await pool?.end().catch(() => {})
-    for (const fixture of fixtures.reverse()) await fixture.close().catch(() => {})
+    await close().catch(() => {})
     throw error
   }
 }

--- a/tests/typescript/integration/api/operator-governed-boot.test.ts
+++ b/tests/typescript/integration/api/operator-governed-boot.test.ts
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Boot-level coverage for the governed Operator wiring: real buildApp(), real provisioning
+// routes and Postgres custody, and the real SDK application transport over HTTP protocol fakes.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  startGovernedOperatorHarness,
+  type GovernedOperatorHarness,
+} from '../../../shared/test-utils/typescript/governed-operator-harness.js'
+
+const databaseUrl = process.env.CARACAL_TEST_DATABASE_URL
+const suite = databaseUrl ? describe : describe.skip
+const envBefore = { ...process.env }
+let harness: GovernedOperatorHarness | undefined
+
+beforeEach(() => {
+  process.env.SECRET_STORE_KEK = '8f3d9a712c45e6b0d18f2a4c6e9b3d57a1c4f8020e6a9c3d5b7f1a2c4e6d8b90'
+  delete process.env.SECRET_STORE_KEK_PREVIOUS
+  process.env.CARACAL_SECRET_BACKEND = 'builtin'
+  process.env.CARACAL_MODE = 'dev'
+})
+
+afterEach(async () => {
+  await harness?.close()
+  harness = undefined
+  process.env = { ...envBefore }
+})
+
+suite('governed Operator boot wiring', () => {
+  it('provisions and seals its model provider before serving through applicationTransport', async () => {
+    harness = await startGovernedOperatorHarness(databaseUrl!)
+    const auth = { authorization: `Bearer ${harness.adminToken}` }
+
+    const status = await fetch(`${harness.apiUrl}/v1/operator/status`, { headers: auth })
+    expect(status.status).toBe(200)
+    const statusBody = (await status.json()) as {
+      system_zone_id: string | null
+      governed_execution: { configured: boolean; zone_id?: string }
+    }
+    expect(statusBody.governed_execution).toEqual({ configured: true, zone_id: statusBody.system_zone_id })
+    expect(statusBody.system_zone_id).toBeTruthy()
+
+    const { rows } = await harness.pool.query<{
+      provider_kind: string
+      config_json: Record<string, unknown>
+      secret_config_keys: string[]
+      resource_identifier: string
+      upstream_url: string
+      envelope: Buffer
+      operator_application_id: string
+    }>(
+      `SELECT p.provider_kind, p.config_json, p.secret_config_keys,
+                r.identifier AS resource_identifier, r.upstream_url, s.envelope,
+                a.id AS operator_application_id
+         FROM zones z
+         JOIN applications a ON a.zone_id = z.id AND a.name = 'caracal.sys/operator' AND a.archived_at IS NULL
+         JOIN providers p ON p.zone_id = z.id AND p.archived_at IS NULL
+         JOIN resources r ON r.zone_id = z.id AND r.credential_provider_id = p.id AND r.archived_at IS NULL
+         JOIN secret_store s ON s.zone_id = z.id AND s.ref = 'zones/' || z.id || '/providers/' || p.id || '/secretConfig'
+         WHERE z.id = $1 AND r.identifier = $2`,
+      [statusBody.system_zone_id, harness.resourceIdentifier],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      provider_kind: 'api_key',
+      secret_config_keys: ['api_key'],
+      resource_identifier: harness.resourceIdentifier,
+    })
+    expect(rows[0].config_json).not.toHaveProperty('api_key')
+    expect(rows[0].upstream_url).toMatch(/^http:\/\/127\.0\.0\.1:/)
+    expect(Buffer.isBuffer(rows[0].envelope)).toBe(true)
+    expect(rows[0].envelope.includes(Buffer.from('upstream-key-must-stay-sealed'))).toBe(false)
+
+    const check = await fetch(`${harness.apiUrl}/v1/operator/ai/check`, { method: 'POST', headers: auth })
+    expect(check.status).toBe(200)
+    expect(await check.json()).toMatchObject({ ok: true, provider: harness.providerId, model: harness.model })
+
+    expect(harness.stsScopes).toEqual(['agent:lifecycle', 'llm:invoke'])
+    expect(harness.stsExchanges).toEqual([
+      { scope: 'agent:lifecycle', zoneId: statusBody.system_zone_id, applicationId: rows[0].operator_application_id },
+      { scope: 'llm:invoke', zoneId: statusBody.system_zone_id, applicationId: rows[0].operator_application_id },
+    ])
+    expect(harness.gatewayCalls).toHaveLength(1)
+    expect(harness.gatewayCalls[0]).toMatchObject({
+      authorization: 'Bearer operator-mandate-1',
+      resource: harness.resourceIdentifier,
+      path: '/chat/completions',
+    })
+    expect(harness.gatewayCalls[0].authorization).not.toContain('upstream-key-must-stay-sealed')
+    expect(harness.gatewayCalls[0].baggage).toContain('caracal.agent_session=operator-session-2')
+    expect(harness.gatewayCalls[0].baggage).toContain('caracal.delegation_edge=operator-delegation-1')
+
+    expect(harness.upstreamCalls).toHaveLength(1)
+    expect(harness.upstreamCalls[0]).toMatchObject({
+      authorization: 'Bearer upstream-key-must-stay-sealed',
+      path: '/v1/chat/completions',
+    })
+    expect(JSON.parse(harness.upstreamCalls[0].body)).toMatchObject({ model: harness.model })
+  }, 45_000)
+})

--- a/tests/typescript/integration/api/operator-governed-boot.test.ts
+++ b/tests/typescript/integration/api/operator-governed-boot.test.ts
@@ -4,7 +4,7 @@
 // Boot-level coverage for the governed Operator wiring: real buildApp(), real provisioning
 // routes and Postgres custody, and the real SDK application transport over HTTP protocol fakes.
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   startGovernedOperatorHarness,
   type GovernedOperatorHarness,
@@ -12,20 +12,21 @@ import {
 
 const databaseUrl = process.env.CARACAL_TEST_DATABASE_URL
 const suite = databaseUrl ? describe : describe.skip
-const envBefore = { ...process.env }
 let harness: GovernedOperatorHarness | undefined
 
 beforeEach(() => {
-  process.env.SECRET_STORE_KEK = '8f3d9a712c45e6b0d18f2a4c6e9b3d57a1c4f8020e6a9c3d5b7f1a2c4e6d8b90'
-  delete process.env.SECRET_STORE_KEK_PREVIOUS
-  process.env.CARACAL_SECRET_BACKEND = 'builtin'
-  process.env.CARACAL_MODE = 'dev'
+  vi.stubEnv('SECRET_STORE_KEK', '8f3d9a712c45e6b0d18f2a4c6e9b3d57a1c4f8020e6a9c3d5b7f1a2c4e6d8b90')
+  vi.stubEnv('CARACAL_SECRET_BACKEND', 'builtin')
+  vi.stubEnv('CARACAL_MODE', 'dev')
 })
 
 afterEach(async () => {
-  await harness?.close()
-  harness = undefined
-  process.env = { ...envBefore }
+  try {
+    await harness?.close()
+  } finally {
+    harness = undefined
+    vi.unstubAllEnvs()
+  }
 })
 
 suite('governed Operator boot wiring', () => {
@@ -71,7 +72,7 @@ suite('governed Operator boot wiring', () => {
     expect(rows[0].config_json).not.toHaveProperty('api_key')
     expect(rows[0].upstream_url).toMatch(/^http:\/\/127\.0\.0\.1:/)
     expect(Buffer.isBuffer(rows[0].envelope)).toBe(true)
-    expect(rows[0].envelope.includes(Buffer.from('upstream-key-must-stay-sealed'))).toBe(false)
+    expect(rows[0].envelope.includes(Buffer.from(harness.upstreamKey))).toBe(false)
 
     const check = await fetch(`${harness.apiUrl}/v1/operator/ai/check`, { method: 'POST', headers: auth })
     expect(check.status).toBe(200)
@@ -88,13 +89,13 @@ suite('governed Operator boot wiring', () => {
       resource: harness.resourceIdentifier,
       path: '/chat/completions',
     })
-    expect(harness.gatewayCalls[0].authorization).not.toContain('upstream-key-must-stay-sealed')
-    expect(harness.gatewayCalls[0].baggage).toContain('caracal.agent_session=operator-session-2')
+    expect(harness.gatewayCalls[0].authorization).not.toContain(harness.upstreamKey)
+    expect(harness.gatewayCalls[0].baggage).toContain(`caracal.agent_session=${harness.sessionIds.at(-1)}`)
     expect(harness.gatewayCalls[0].baggage).toContain('caracal.delegation_edge=operator-delegation-1')
 
     expect(harness.upstreamCalls).toHaveLength(1)
     expect(harness.upstreamCalls[0]).toMatchObject({
-      authorization: 'Bearer upstream-key-must-stay-sealed',
+      authorization: `Bearer ${harness.upstreamKey}`,
       path: '/v1/chat/completions',
     })
     expect(JSON.parse(harness.upstreamCalls[0].body)).toMatchObject({ model: harness.model })


### PR DESCRIPTION
## Summary

- add a reusable boot-level governed Operator harness for this issue and the full-lifecycle work in #355
- boot the real `buildApp()` against migrated PostgreSQL while replacing only the separately deployed STS, Coordinator, Gateway, and OpenAI-compatible upstream with HTTP protocol fakes
- verify system-zone provisioning, encrypted provider custody, generated application credentials, lifecycle and scoped mandate exchanges, delegated Gateway routing, and delivery to the upstream without exposing the upstream key at the Operator boundary
- keep retry, abort, streaming, and other scenario coverage in their owning issues as requested

## Validation

- focused real-PostgreSQL boot integration test: 10/10 consecutive passes on the final implementation
- clean-database migration plus first-boot pass
- full PostgreSQL integration suite: 12/12 passed
- repository TypeScript tests: 3,231 passed (database-only test separately exercised above)
- `pnpm run style`
- `pnpm run build:typescript`
- `pnpm run lint`
- `pnpm run typecheck`

Closes #351


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for governed Operator startup and boot configuration.
  * Verified provider, resource, and secret persistence during initialization.
  * Added checks for AI request handling, authorization scopes, delegation headers, credential protection, metadata propagation, and upstream requests.
  * Added reusable test infrastructure for running the real API and database with local service fixtures.
  * Updated integration workflows to prepare required runtime assets before testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->