### PR TITLE
fix(api): unify egress address validation

### DIFF
--- a/apps/api/src/egress-address.ts
+++ b/apps/api/src/egress-address.ts
@@ -23,18 +23,19 @@ privateBlocked.addSubnet('172.16.0.0', 12, 'ipv4')
 privateBlocked.addSubnet('192.168.0.0', 16, 'ipv4')
 privateBlocked.addSubnet('fc00::', 7, 'ipv6')
 
+const nat64WellKnownPrefix = new BlockList()
+nat64WellKnownPrefix.addSubnet('64:ff9b::', 96, 'ipv6')
+
 // Extract the IPv4 address embedded in a NAT64 well-known-prefix address
 // (64:ff9b::/96, RFC 6052), or null when value is not such an address.
 function nat64EmbeddedIpv4(value: string): string | null {
-  const lower = value.toLowerCase()
-  if (!lower.startsWith('64:ff9b::')) return null
-  const tail = lower.slice('64:ff9b::'.length)
-  if (tail === '') return null
-  if (tail.includes('.')) return isIP(tail) === 4 ? tail : null
-  const groups = tail.split(':')
-  if (groups.length < 2) return null
-  const hi = Number.parseInt(groups.at(-2)!, 16)
-  const lo = Number.parseInt(groups.at(-1)!, 16)
+  if (isIP(value) !== 6 || !nat64WellKnownPrefix.check(value, 'ipv6')) return null
+
+  const canonical = normalizedUrlHostname(new URL(`http://[${value}]/`))
+  const groups = canonical.slice('64:ff9b::'.length).split(':').filter(Boolean)
+  if (groups.length > 2) return null
+  const hi = groups.length === 2 ? Number.parseInt(groups[0]!, 16) : 0
+  const lo = groups.length > 0 ? Number.parseInt(groups.at(-1)!, 16) : 0
   if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi > 0xffff || lo > 0xffff) return null
   return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
 }

--- a/apps/api/src/egress-address.ts
+++ b/apps/api/src/egress-address.ts
@@ -1,5 +1,7 @@
 // Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
 // Caracal, a product of Garudex Labs
+//
+// Normalizes and classifies egress addresses that outbound requests must never reach.
 
 import { BlockList, isIP } from 'node:net'
 
@@ -8,6 +10,7 @@ alwaysBlocked.addSubnet('0.0.0.0', 8, 'ipv4')
 alwaysBlocked.addSubnet('127.0.0.0', 8, 'ipv4')
 alwaysBlocked.addSubnet('169.254.0.0', 16, 'ipv4')
 alwaysBlocked.addSubnet('224.0.0.0', 4, 'ipv4')
+alwaysBlocked.addSubnet('240.0.0.0', 4, 'ipv4')
 alwaysBlocked.addAddress('::', 'ipv6')
 alwaysBlocked.addAddress('::1', 'ipv6')
 alwaysBlocked.addSubnet('fe80::', 10, 'ipv6')
@@ -34,6 +37,10 @@ function nat64EmbeddedIpv4(value: string): string | null {
   const lo = Number.parseInt(groups.at(-1)!, 16)
   if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi > 0xffff || lo > 0xffff) return null
   return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
+}
+
+export function normalizedUrlHostname(url: URL): string {
+  return url.hostname.startsWith('[') && url.hostname.endsWith(']') ? url.hostname.slice(1, -1) : url.hostname
 }
 
 export function isUnsafeEgressAddress(value: string, privateAllowed = false): boolean {

--- a/apps/api/src/egress-address.ts
+++ b/apps/api/src/egress-address.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+
+import { BlockList, isIP } from 'node:net'
+
+const alwaysBlocked = new BlockList()
+alwaysBlocked.addSubnet('0.0.0.0', 8, 'ipv4')
+alwaysBlocked.addSubnet('127.0.0.0', 8, 'ipv4')
+alwaysBlocked.addSubnet('169.254.0.0', 16, 'ipv4')
+alwaysBlocked.addSubnet('224.0.0.0', 4, 'ipv4')
+alwaysBlocked.addAddress('::', 'ipv6')
+alwaysBlocked.addAddress('::1', 'ipv6')
+alwaysBlocked.addSubnet('fe80::', 10, 'ipv6')
+alwaysBlocked.addSubnet('ff00::', 8, 'ipv6')
+
+const privateBlocked = new BlockList()
+privateBlocked.addSubnet('10.0.0.0', 8, 'ipv4')
+privateBlocked.addSubnet('100.64.0.0', 10, 'ipv4')
+privateBlocked.addSubnet('172.16.0.0', 12, 'ipv4')
+privateBlocked.addSubnet('192.168.0.0', 16, 'ipv4')
+privateBlocked.addSubnet('fc00::', 7, 'ipv6')
+
+// Extract the IPv4 address embedded in a NAT64 well-known-prefix address
+// (64:ff9b::/96, RFC 6052), or null when value is not such an address.
+function nat64EmbeddedIpv4(value: string): string | null {
+  const lower = value.toLowerCase()
+  if (!lower.startsWith('64:ff9b::')) return null
+  const tail = lower.slice('64:ff9b::'.length)
+  if (tail === '') return null
+  if (tail.includes('.')) return isIP(tail) === 4 ? tail : null
+  const groups = tail.split(':')
+  if (groups.length < 2) return null
+  const hi = Number.parseInt(groups.at(-2)!, 16)
+  const lo = Number.parseInt(groups.at(-1)!, 16)
+  if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi > 0xffff || lo > 0xffff) return null
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
+}
+
+export function isUnsafeEgressAddress(value: string, privateAllowed = false): boolean {
+  const nat64 = nat64EmbeddedIpv4(value)
+  if (nat64) return isUnsafeEgressAddress(nat64, privateAllowed)
+
+  const version = isIP(value)
+  if (version === 0) return true
+  const family = version === 4 ? 'ipv4' : 'ipv6'
+  return alwaysBlocked.check(value, family) || (!privateAllowed && privateBlocked.check(value, family))
+}

--- a/apps/api/src/jobs/notification-dispatcher.ts
+++ b/apps/api/src/jobs/notification-dispatcher.ts
@@ -13,7 +13,7 @@ import { v7 as uuidv7 } from 'uuid'
 import { newTraceContext, runWithTrace } from '@caracalai/core'
 import { AAD_NOTIFICATION_SINK_SECRET, openSecretEnvelope } from '@caracalai/server-core'
 import type { DB } from '../db.js'
-import { isUnsafeEgressAddress } from '../egress-address.js'
+import { isUnsafeEgressAddress, normalizedUrlHostname } from '../egress-address.js'
 import { withTransaction } from '../db.js'
 import { privateEgressHosts } from '../provider-token.js'
 
@@ -108,8 +108,6 @@ function openSecret(packed: Buffer): string {
   }
 }
 
-export const isUnsafeSinkAddress = isUnsafeEgressAddress
-
 async function defaultSinkResolver(host: string): Promise<SinkAddress[]> {
   if (isIP(host) !== 0) return [{ address: host, family: isIP(host) as 4 | 6 }]
   return (await lookup(host, { all: true, verbatim: true })).filter(
@@ -123,13 +121,12 @@ export async function postNotificationSink(
   resolve: SinkResolver = defaultSinkResolver,
 ): Promise<{ status: number }> {
   const target = new URL(rawUrl)
-  const addresses = await resolve(target.hostname)
+  const hostname = normalizedUrlHostname(target)
+  const addresses = await resolve(hostname)
   if (addresses.length === 0) throw new Error('sink host resolves to no addresses')
-  const loopbackDevelopment =
-    target.protocol === 'http:' &&
-    (target.hostname === 'localhost' || target.hostname === '127.0.0.1' || target.hostname === '[::1]' || target.hostname === '::1')
-  const privateAllowed = privateEgressHosts().has(target.hostname.toLowerCase())
-  if (!loopbackDevelopment && addresses.some((entry) => isUnsafeSinkAddress(entry.address, privateAllowed))) {
+  const loopbackDevelopment = target.protocol === 'http:' && (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1')
+  const privateAllowed = privateEgressHosts().has(hostname.toLowerCase())
+  if (!loopbackDevelopment && addresses.some((entry) => isUnsafeEgressAddress(entry.address, privateAllowed))) {
     throw new Error('sink host resolves to a restricted address')
   }
   const address = addresses[0]

--- a/apps/api/src/jobs/notification-dispatcher.ts
+++ b/apps/api/src/jobs/notification-dispatcher.ts
@@ -13,6 +13,7 @@ import { v7 as uuidv7 } from 'uuid'
 import { newTraceContext, runWithTrace } from '@caracalai/core'
 import { AAD_NOTIFICATION_SINK_SECRET, openSecretEnvelope } from '@caracalai/server-core'
 import type { DB } from '../db.js'
+import { isUnsafeEgressAddress } from '../egress-address.js'
 import { withTransaction } from '../db.js'
 import { privateEgressHosts } from '../provider-token.js'
 
@@ -107,47 +108,7 @@ function openSecret(packed: Buffer): string {
   }
 }
 
-function nat64EmbeddedIpv4(value: string): string | null {
-  const lower = value.toLowerCase()
-  if (!lower.startsWith('64:ff9b::')) return null
-  const tail = lower.slice('64:ff9b::'.length)
-  if (tail.includes('.')) return isIP(tail) === 4 ? tail : null
-  const groups = tail.split(':')
-  if (groups.length < 2) return null
-  const hi = Number.parseInt(groups.at(-2)!, 16)
-  const lo = Number.parseInt(groups.at(-1)!, 16)
-  if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi > 0xffff || lo > 0xffff) return null
-  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
-}
-
-export function isUnsafeSinkAddress(value: string, privateAllowed = false): boolean {
-  const nat64 = nat64EmbeddedIpv4(value)
-  if (nat64) return isUnsafeSinkAddress(nat64, privateAllowed)
-  const ip = value.toLowerCase().startsWith('::ffff:') ? value.slice(7) : value
-  if (isIP(ip) === 4) {
-    const parts = ip.split('.').map(Number)
-    return (
-      parts[0] === 0 ||
-      (parts[0] === 10 && !privateAllowed) ||
-      parts[0] === 127 ||
-      (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127 && !privateAllowed) ||
-      (parts[0] === 169 && parts[1] === 254) ||
-      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31 && !privateAllowed) ||
-      (parts[0] === 192 && parts[1] === 168 && !privateAllowed) ||
-      parts[0] >= 224
-    )
-  }
-  const lower = ip.toLowerCase()
-  return (
-    isIP(ip) !== 6 ||
-    lower === '::' ||
-    lower === '::1' ||
-    (lower.startsWith('fc') && !privateAllowed) ||
-    (lower.startsWith('fd') && !privateAllowed) ||
-    lower.startsWith('fe80:') ||
-    lower.startsWith('ff')
-  )
-}
+export const isUnsafeSinkAddress = isUnsafeEgressAddress
 
 async function defaultSinkResolver(host: string): Promise<SinkAddress[]> {
   if (isIP(host) !== 0) return [{ address: host, family: isIP(host) as 4 | 6 }]

--- a/apps/api/src/provider-token.ts
+++ b/apps/api/src/provider-token.ts
@@ -80,14 +80,14 @@ export function ensureAllowedTokenEndpoint(raw: string, hosts: string[]): URL {
   return ensureAllowedHttpsEndpoint(raw, hosts, 'provider token endpoint')
 }
 
-export const isUnsafeIpAddress = isUnsafeEgressAddress
-
 async function resolveSafeHost(host: string): Promise<{ address: string; family: 4 | 6 }[]> {
   const addresses = await lookup(host, { all: true, verbatim: false })
   if (addresses.length === 0) throw new Error('provider token endpoint resolves to no addresses')
   const privateAllowed = privateEgressHosts().has(host.toLowerCase())
   for (const address of addresses) {
-    if (isUnsafeIpAddress(address.address, privateAllowed)) throw new Error('provider token endpoint resolves to a non-routable address')
+    if (isUnsafeEgressAddress(address.address, privateAllowed)) {
+      throw new Error('provider token endpoint resolves to a non-routable address')
+    }
   }
   return addresses.filter((address): address is { address: string; family: 4 | 6 } => address.family === 4 || address.family === 6)
 }

--- a/apps/api/src/provider-token.ts
+++ b/apps/api/src/provider-token.ts
@@ -7,8 +7,9 @@ import { createHash, createPrivateKey, generateKeyPairSync, randomUUID, sign, X5
 import { lookup } from 'node:dns/promises'
 import { request as httpRequest } from 'node:http'
 import { request as httpsRequest } from 'node:https'
-import { isIP, type LookupFunction } from 'node:net'
+import { type LookupFunction } from 'node:net'
 import { providerSecretConfigRef, type SecretBackend } from '@caracalai/server-core'
+import { isUnsafeEgressAddress } from './egress-address.js'
 
 const PROVIDER_TOKEN_EXCHANGE_TIMEOUT_MS = 15_000
 const PROVIDER_TOKEN_EXCHANGE_MAX_BODY_BYTES = 64 * 1024
@@ -79,53 +80,7 @@ export function ensureAllowedTokenEndpoint(raw: string, hosts: string[]): URL {
   return ensureAllowedHttpsEndpoint(raw, hosts, 'provider token endpoint')
 }
 
-// Extract the IPv4 address embedded in a NAT64 well-known-prefix address
-// (64:ff9b::/96, RFC 6052), or null when value is not such an address.
-function nat64EmbeddedIpv4(value: string): string | null {
-  const lower = value.toLowerCase()
-  if (!lower.startsWith('64:ff9b::')) return null
-  const tail = lower.slice('64:ff9b::'.length)
-  if (tail === '') return null
-  if (tail.includes('.')) {
-    return isIP(tail) === 4 ? tail : null
-  }
-  const groups = tail.split(':')
-  if (groups.length < 2) return null
-  const hi = Number.parseInt(groups[groups.length - 2]!, 16)
-  const lo = Number.parseInt(groups[groups.length - 1]!, 16)
-  if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi > 0xffff || lo > 0xffff) return null
-  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
-}
-
-export function isUnsafeIpAddress(value: string, privateAllowed = false): boolean {
-  const nat64 = nat64EmbeddedIpv4(value)
-  if (nat64) return isUnsafeIpAddress(nat64, privateAllowed)
-  const ip = value.startsWith('::ffff:') ? value.slice(7) : value
-  const family = isIP(ip)
-  if (family === 4) {
-    const parts = ip.split('.').map(Number)
-    return (
-      parts[0] === 0 ||
-      (parts[0] === 10 && !privateAllowed) ||
-      parts[0] === 127 ||
-      (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127 && !privateAllowed) ||
-      (parts[0] === 169 && parts[1] === 254) ||
-      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31 && !privateAllowed) ||
-      (parts[0] === 192 && parts[1] === 168 && !privateAllowed) ||
-      parts[0] >= 224
-    )
-  }
-  const lower = ip.toLowerCase()
-  return (
-    family === 6 &&
-    (lower === '::' ||
-      lower === '::1' ||
-      (lower.startsWith('fc') && !privateAllowed) ||
-      (lower.startsWith('fd') && !privateAllowed) ||
-      lower.startsWith('fe80:') ||
-      lower.startsWith('ff'))
-  )
-}
+export const isUnsafeIpAddress = isUnsafeEgressAddress
 
 async function resolveSafeHost(host: string): Promise<{ address: string; family: 4 | 6 }[]> {
   const addresses = await lookup(host, { all: true, verbatim: false })

--- a/apps/api/src/routes/notification-sinks.ts
+++ b/apps/api/src/routes/notification-sinks.ts
@@ -12,7 +12,7 @@ import { AAD_NOTIFICATION_SINK_SECRET, sealSecretEnvelope } from '@caracalai/ser
 import { ZoneIdParams, ZoneParams, parseParams } from './params.js'
 import { appendKeysetCondition, listPage, parseListPagination } from './list-pagination.js'
 import { zoneExists } from '../zone-guard.js'
-import { isUnsafeSinkAddress } from '../jobs/notification-dispatcher.js'
+import { isUnsafeEgressAddress, normalizedUrlHostname } from '../egress-address.js'
 
 // The event types a sink may subscribe to: the approval lifecycle as recorded in the zone
 // audit stream. The dispatcher fans out exactly these, so the subscription surface and the
@@ -45,9 +45,9 @@ export function validateSinkUrl(raw: string): string | null {
     return 'sink url is not a valid absolute URL'
   }
   if (url.username || url.password) return 'sink url must not embed credentials'
-  const hostname = url.hostname.startsWith('[') && url.hostname.endsWith(']') ? url.hostname.slice(1, -1) : url.hostname
+  const hostname = normalizedUrlHostname(url)
   const loopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
-  if (isIP(hostname) !== 0 && isUnsafeSinkAddress(hostname) && !(url.protocol === 'http:' && loopback)) {
+  if (isIP(hostname) !== 0 && isUnsafeEgressAddress(hostname) && !(url.protocol === 'http:' && loopback)) {
     return 'sink url must not target a restricted address'
   }
   if (url.protocol === 'https:') return null

--- a/apps/api/src/routes/notification-sinks.ts
+++ b/apps/api/src/routes/notification-sinks.ts
@@ -45,8 +45,9 @@ export function validateSinkUrl(raw: string): string | null {
     return 'sink url is not a valid absolute URL'
   }
   if (url.username || url.password) return 'sink url must not embed credentials'
-  const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]' || url.hostname === '::1'
-  if (isIP(url.hostname) !== 0 && isUnsafeSinkAddress(url.hostname) && !(url.protocol === 'http:' && loopback)) {
+  const hostname = url.hostname.startsWith('[') && url.hostname.endsWith(']') ? url.hostname.slice(1, -1) : url.hostname
+  const loopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
+  if (isIP(hostname) !== 0 && isUnsafeSinkAddress(hostname) && !(url.protocol === 'http:' && loopback)) {
     return 'sink url must not target a restricted address'
   }
   if (url.protocol === 'https:') return null

--- a/tests/typescript/unit/api/jobs/notification-dispatcher.test.ts
+++ b/tests/typescript/unit/api/jobs/notification-dispatcher.test.ts
@@ -85,13 +85,19 @@ describe('notification sink destination safety', () => {
       '::1',
       'fd00::1',
       'fe80::1',
+      'fe8f::1',
+      'fe90::1',
+      'fea0::1',
+      'febf::1',
       '::ffff:127.0.0.1',
+      '::FFFF:127.0.0.1',
       '64:ff9b::a00:1',
     ]) {
       expect(isUnsafeSinkAddress(address), address).toBe(true)
     }
     expect(isUnsafeSinkAddress('203.0.113.10')).toBe(false)
     expect(isUnsafeSinkAddress('2001:db8::10')).toBe(false)
+    expect(isUnsafeSinkAddress('fec0::1')).toBe(false)
   })
 
   it('fails before connecting when any resolved address is restricted', async () => {
@@ -121,7 +127,7 @@ describe('notification sink destination safety', () => {
       expect(isUnsafeSinkAddress(address, true), address).toBe(false)
     }
     // Allowlisting a private receiver must never open loopback, link-local, metadata, or multicast.
-    for (const address of ['127.0.0.1', '169.254.169.254', '::1', 'fe80::1', '224.0.0.1']) {
+    for (const address of ['127.0.0.1', '169.254.169.254', '::1', 'fe80::1', 'fe8f::1', 'febf::1', '224.0.0.1']) {
       expect(isUnsafeSinkAddress(address, true), address).toBe(true)
     }
   })

--- a/tests/typescript/unit/api/jobs/notification-dispatcher.test.ts
+++ b/tests/typescript/unit/api/jobs/notification-dispatcher.test.ts
@@ -21,8 +21,9 @@ afterEach(() => {
   delete process.env.SECRET_STORE_KEK
 })
 
-const { isUnsafeSinkAddress, postNotificationSink, runNotificationDispatch, signSinkPayload, sinkBackoffSeconds, sinkPayload } =
+const { postNotificationSink, runNotificationDispatch, signSinkPayload, sinkBackoffSeconds, sinkPayload } =
   await import('../../../../../apps/api/src/jobs/notification-dispatcher.js')
+const { isUnsafeEgressAddress } = await import('../../../../../apps/api/src/egress-address.js')
 const { AAD_NOTIFICATION_SINK_SECRET, loadSecretStoreKek, sealEnvelope } = await import('@caracalai/server-core')
 import type { DB } from '../../../../../apps/api/src/db.js'
 import type { SinkFetch } from '../../../../../apps/api/src/jobs/notification-dispatcher.js'
@@ -92,12 +93,15 @@ describe('notification sink destination safety', () => {
       '::ffff:127.0.0.1',
       '::FFFF:127.0.0.1',
       '64:ff9b::a00:1',
+      '240.0.0.1',
+      '250.1.2.3',
+      '255.255.255.255',
     ]) {
-      expect(isUnsafeSinkAddress(address), address).toBe(true)
+      expect(isUnsafeEgressAddress(address), address).toBe(true)
     }
-    expect(isUnsafeSinkAddress('203.0.113.10')).toBe(false)
-    expect(isUnsafeSinkAddress('2001:db8::10')).toBe(false)
-    expect(isUnsafeSinkAddress('fec0::1')).toBe(false)
+    expect(isUnsafeEgressAddress('203.0.113.10')).toBe(false)
+    expect(isUnsafeEgressAddress('2001:db8::10')).toBe(false)
+    expect(isUnsafeEgressAddress('fec0::1')).toBe(false)
   })
 
   it('fails before connecting when any resolved address is restricted', async () => {
@@ -119,16 +123,34 @@ describe('notification sink destination safety', () => {
     ).rejects.toThrow('restricted address')
   })
 
+  it('normalizes bracketed IPv6 literals before dispatch-time resolution', async () => {
+    const resolve = vi.fn(async () => [] as { address: string; family: 4 | 6 }[])
+    await expect(
+      postNotificationSink(
+        'http://[::1]/hook',
+        {
+          method: 'POST',
+          headers: {},
+          body: '{}',
+          redirect: 'error',
+          signal: AbortSignal.timeout(1_000),
+        },
+        resolve,
+      ),
+    ).rejects.toThrow('resolves to no addresses')
+    expect(resolve).toHaveBeenCalledWith('::1')
+  })
+
   it('relaxes private and ULA ranges only when the host is on the egress allowlist, never loopback or metadata', () => {
     // Default posture blocks every private range; the allowlist flag relaxes exactly the
     // operator-routable private ranges so an internal receiver can be reached deliberately.
     for (const address of ['10.0.0.1', '172.17.0.1', '192.168.1.1', '100.64.0.1', 'fd00::1']) {
-      expect(isUnsafeSinkAddress(address), address).toBe(true)
-      expect(isUnsafeSinkAddress(address, true), address).toBe(false)
+      expect(isUnsafeEgressAddress(address), address).toBe(true)
+      expect(isUnsafeEgressAddress(address, true), address).toBe(false)
     }
     // Allowlisting a private receiver must never open loopback, link-local, metadata, or multicast.
     for (const address of ['127.0.0.1', '169.254.169.254', '::1', 'fe80::1', 'fe8f::1', 'febf::1', '224.0.0.1']) {
-      expect(isUnsafeSinkAddress(address, true), address).toBe(true)
+      expect(isUnsafeEgressAddress(address, true), address).toBe(true)
     }
   })
 

--- a/tests/typescript/unit/api/jobs/notification-dispatcher.test.ts
+++ b/tests/typescript/unit/api/jobs/notification-dispatcher.test.ts
@@ -93,6 +93,10 @@ describe('notification sink destination safety', () => {
       '::ffff:127.0.0.1',
       '::FFFF:127.0.0.1',
       '64:ff9b::a00:1',
+      '64:ff9b:0:0:0:0:a00:1',
+      '0064:ff9b::a00:1',
+      '64:ff9b::10.0.0.1',
+      '64:ff9b::1',
       '240.0.0.1',
       '250.1.2.3',
       '255.255.255.255',
@@ -102,6 +106,7 @@ describe('notification sink destination safety', () => {
     expect(isUnsafeEgressAddress('203.0.113.10')).toBe(false)
     expect(isUnsafeEgressAddress('2001:db8::10')).toBe(false)
     expect(isUnsafeEgressAddress('fec0::1')).toBe(false)
+    expect(isUnsafeEgressAddress('64:ff9b:0:0:1:2:a00:1')).toBe(false)
   })
 
   it('fails before connecting when any resolved address is restricted', async () => {

--- a/tests/typescript/unit/api/routes/notification-sinks.test.ts
+++ b/tests/typescript/unit/api/routes/notification-sinks.test.ts
@@ -37,6 +37,9 @@ describe('validateSinkUrl', () => {
     expect(validateSinkUrl('ftp://hooks.hooli.example/')).toContain('https')
     expect(validateSinkUrl('https://169.254.169.254/latest/meta-data')).toContain('restricted')
     expect(validateSinkUrl('https://10.0.0.1/hook')).toContain('restricted')
+    expect(validateSinkUrl('https://[::1]/hook')).toContain('restricted')
+    expect(validateSinkUrl('https://[fe90::1]/hook')).toContain('restricted')
+    expect(validateSinkUrl('http://[::1]/hook')).toBeNull()
   })
 })
 

--- a/tests/typescript/unit/api/routes/provider-connections.test.ts
+++ b/tests/typescript/unit/api/routes/provider-connections.test.ts
@@ -613,45 +613,48 @@ describe('OAuth provider grant browser flow', () => {
     expect(httpsRequest).not.toHaveBeenCalled()
   })
 
-  it('rejects callback token endpoints that resolve to NAT64-embedded metadata addresses', async () => {
-    const { app, db, redis, secrets } = buildRouteApp(providerConnectionsRoutes)
-    const state = 'abcdefghijklmnopqrstuvwxyz1234567890'
-    seedProviderSecret(secrets)
-    redis.call.mockResolvedValue(
-      JSON.stringify({
-        zone_id: 'z1',
-        subject_id: 'user-1',
-        provider_id: 'provider-1',
-        code_verifier: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-._~',
-      }),
-    )
-    db.query.mockResolvedValueOnce({
-      rows: [
-        {
-          id: 'provider-1',
-          provider_kind: 'oauth2_authorization_code',
-          config_json: {
-            token_endpoint: 'https://oauth2.googleapis.com/token',
-            redirect_uri: 'http://localhost:3000/v1/zones/z1/provider-connections/oauth/callback',
-            client_id: 'google-client',
-            client_auth_method: 'client_secret_basic',
-            allowed_token_hosts: ['oauth2.googleapis.com'],
+  it.each(['64:ff9b::a9fe:a9fe', '64:ff9b:0:0:0:0:a9fe:a9fe'])(
+    'rejects callback token endpoints that resolve to NAT64-embedded metadata address %s',
+    async (address) => {
+      const { app, db, redis, secrets } = buildRouteApp(providerConnectionsRoutes)
+      const state = 'abcdefghijklmnopqrstuvwxyz1234567890'
+      seedProviderSecret(secrets)
+      redis.call.mockResolvedValue(
+        JSON.stringify({
+          zone_id: 'z1',
+          subject_id: 'user-1',
+          provider_id: 'provider-1',
+          code_verifier: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-._~',
+        }),
+      )
+      db.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'provider-1',
+            provider_kind: 'oauth2_authorization_code',
+            config_json: {
+              token_endpoint: 'https://oauth2.googleapis.com/token',
+              redirect_uri: 'http://localhost:3000/v1/zones/z1/provider-connections/oauth/callback',
+              client_id: 'google-client',
+              client_auth_method: 'client_secret_basic',
+              allowed_token_hosts: ['oauth2.googleapis.com'],
+            },
           },
-        },
-      ],
-    })
-    vi.mocked(lookup).mockResolvedValue([{ address: '64:ff9b:0:0:0:0:a9fe:a9fe', family: 6 }])
+        ],
+      })
+      vi.mocked(lookup).mockResolvedValue([{ address, family: 6 }])
 
-    await app.ready()
-    const res = await app.inject({
-      method: 'GET',
-      url: `/v1/zones/z1/provider-connections/oauth/callback?state=${state}&code=provider-code`,
-    })
+      await app.ready()
+      const res = await app.inject({
+        method: 'GET',
+        url: `/v1/zones/z1/provider-connections/oauth/callback?state=${state}&code=provider-code`,
+      })
 
-    expect(res.statusCode).toBe(502)
-    expect(JSON.parse(res.body)).toMatchObject({ error: 'provider_token_exchange_failed' })
-    expect(httpsRequest).not.toHaveBeenCalled()
-  })
+      expect(res.statusCode).toBe(502)
+      expect(JSON.parse(res.body)).toMatchObject({ error: 'provider_token_exchange_failed' })
+      expect(httpsRequest).not.toHaveBeenCalled()
+    },
+  )
 
   it('rejects callback token endpoints that resolve to IPv4-mapped metadata addresses', async () => {
     const { app, db, redis, secrets } = buildRouteApp(providerConnectionsRoutes)

--- a/tests/typescript/unit/api/routes/provider-connections.test.ts
+++ b/tests/typescript/unit/api/routes/provider-connections.test.ts
@@ -640,7 +640,7 @@ describe('OAuth provider grant browser flow', () => {
         },
       ],
     })
-    vi.mocked(lookup).mockResolvedValue([{ address: '64:ff9b::a9fe:a9fe', family: 6 }])
+    vi.mocked(lookup).mockResolvedValue([{ address: '64:ff9b:0:0:0:0:a9fe:a9fe', family: 6 }])
 
     await app.ready()
     const res = await app.inject({

--- a/tests/typescript/unit/api/routes/providers.test.ts
+++ b/tests/typescript/unit/api/routes/providers.test.ts
@@ -32,6 +32,10 @@ describe('provider private egress policy', () => {
       'febf::1',
       '::FFFF:127.0.0.1',
       '64:ff9b::a9fe:a9fe',
+      '64:ff9b:0:0:0:0:a9fe:a9fe',
+      '0064:ff9b::a9fe:a9fe',
+      '64:ff9b::169.254.169.254',
+      '64:ff9b::1',
       '240.0.0.1',
       '250.1.2.3',
       '255.255.255.255',
@@ -39,6 +43,7 @@ describe('provider private egress policy', () => {
       expect(isUnsafeEgressAddress(address, true), address).toBe(true)
     }
     expect(isUnsafeEgressAddress('fec0::1'), 'fec0::1').toBe(false)
+    expect(isUnsafeEgressAddress('64:ff9b:0:0:1:2:a9fe:a9fe'), 'outside 64:ff9b::/96').toBe(false)
   })
 })
 

--- a/tests/typescript/unit/api/routes/providers.test.ts
+++ b/tests/typescript/unit/api/routes/providers.test.ts
@@ -10,7 +10,7 @@ import { lookup } from 'node:dns/promises'
 import { request as httpsRequest } from 'node:https'
 import { SecretBackendError, providerSecretConfigRef } from '@caracalai/server-core'
 import { providersRoutes } from '../../../../../apps/api/src/routes/providers.js'
-import { isUnsafeIpAddress } from '../../../../../apps/api/src/provider-token.js'
+import { isUnsafeEgressAddress } from '../../../../../apps/api/src/egress-address.js'
 import { buildRouteApp } from '../../../../shared/test-utils/typescript/fastify.js'
 
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }))
@@ -19,7 +19,7 @@ vi.mock('node:https', () => ({ request: vi.fn() }))
 describe('provider private egress policy', () => {
   it('allows explicitly granted private ranges but never metadata or loopback ranges', () => {
     for (const address of ['10.0.0.1', '172.16.0.1', '192.168.0.1', '100.64.0.1', 'fd00::1']) {
-      expect(isUnsafeIpAddress(address, true), address).toBe(false)
+      expect(isUnsafeEgressAddress(address, true), address).toBe(false)
     }
     for (const address of [
       '127.0.0.1',
@@ -32,10 +32,13 @@ describe('provider private egress policy', () => {
       'febf::1',
       '::FFFF:127.0.0.1',
       '64:ff9b::a9fe:a9fe',
+      '240.0.0.1',
+      '250.1.2.3',
+      '255.255.255.255',
     ]) {
-      expect(isUnsafeIpAddress(address, true), address).toBe(true)
+      expect(isUnsafeEgressAddress(address, true), address).toBe(true)
     }
-    expect(isUnsafeIpAddress('fec0::1'), 'fec0::1').toBe(false)
+    expect(isUnsafeEgressAddress('fec0::1'), 'fec0::1').toBe(false)
   })
 })
 

--- a/tests/typescript/unit/api/routes/providers.test.ts
+++ b/tests/typescript/unit/api/routes/providers.test.ts
@@ -21,9 +21,21 @@ describe('provider private egress policy', () => {
     for (const address of ['10.0.0.1', '172.16.0.1', '192.168.0.1', '100.64.0.1', 'fd00::1']) {
       expect(isUnsafeIpAddress(address, true), address).toBe(false)
     }
-    for (const address of ['127.0.0.1', '169.254.169.254', '::1', 'fe80::1', '64:ff9b::a9fe:a9fe']) {
+    for (const address of [
+      '127.0.0.1',
+      '169.254.169.254',
+      '::1',
+      'fe80::1',
+      'fe8f::1',
+      'fe90::1',
+      'fea0::1',
+      'febf::1',
+      '::FFFF:127.0.0.1',
+      '64:ff9b::a9fe:a9fe',
+    ]) {
       expect(isUnsafeIpAddress(address, true), address).toBe(true)
     }
+    expect(isUnsafeIpAddress('fec0::1'), 'fec0::1').toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

- consolidate provider and notification sink egress checks into one shared CIDR-aware classifier
- correctly reject the complete IPv6 link-local `fe80::/10` range
- preserve blocking of IPv4 multicast, reserved, and broadcast ranges through `255.255.255.255`
- consistently classify IPv4-mapped IPv6 addresses regardless of casing
- normalize bracketed IPv6 literals during both sink validation and dispatch-time resolution
- remove duplicated classifier implementations and compatibility aliases

## Problem

Provider token requests and notification sink deliveries maintained separate copies of the egress address classifier. These implementations had drifted and only recognized `fe80::/16`, while IPv6 link-local addresses occupy `fe80::/10`.

Notification sink validation also passed bracketed hostnames such as `[::1]` directly to `isIP()`. Node does not recognize the bracketed value as an IP address, allowing IPv6 literals to bypass route-level restricted-address validation.

## Solution

This PR introduces a shared `egress-address` module using Node's CIDR-aware `BlockList`. Both provider and notification paths now use that implementation.

It also centralizes URL hostname normalization so bracketed IPv6 literals are consistently handled during initial validation, allowlist lookup, DNS resolution, and dispatch-time safety checks.

The existing local-development behavior remains unchanged: `http://[::1]` is permitted for loopback sinks, while restricted IPv6 literals over HTTPS are rejected.

Regression coverage includes:

- the complete `fe80::/10` link-local range
- the `fec0::/10` boundary immediately outside that range
- uppercase IPv4-mapped IPv6 addresses
- IPv4 addresses in `240.0.0.0/4`
- `255.255.255.255`
- bracketed IPv6 sink validation and dispatch-time normalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Strengthened outbound connection checks for notification sinks and provider token requests.
  - Blocks unsafe private, loopback, link-local, multicast, reserved, metadata, and carrier-grade NAT addresses.
  - Added comprehensive IPv4 and IPv6 protection, including bracketed IPv6 hostnames and NAT64 addresses.
  - Preserves approved private-network exceptions and local HTTP development access.

- **Bug Fixes**
  - Prevents restricted IPv6 destinations from bypassing URL validation.
  - Improves detection of mapped and specially reserved IP addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->