### PR TITLE
fix(operator): stop plan execution after lease loss

### DIFF
--- a/apps/api/src/operator-control-client.ts
+++ b/apps/api/src/operator-control-client.ts
@@ -32,6 +32,9 @@ export interface OperatorControlClientInput {
   authorizedBy?: string
   coAuthorOperator?: boolean
   requestId?: string
+  // Cancels token minting or control dispatch when the execution lease that authorizes
+  // this client is no longer owned. The ControlClient combines it with its own timeout.
+  signal?: AbortSignal
 }
 
 // Builds the governed control client for one Operator role, or null when governed execution
@@ -54,6 +57,7 @@ export function buildOperatorControlClient(input: OperatorControlClientInput): C
     authorizedBy: input.authorizedBy,
     coAuthorOperator: input.coAuthorOperator,
     requestId: input.requestId,
+    signal: input.signal,
     fetchImpl: input.fetchImpl,
   })
 }

--- a/apps/api/src/operator-execution-lease.ts
+++ b/apps/api/src/operator-execution-lease.ts
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Fail-closed ownership guard for an acquired Operator plan-execution lock.
+
+import type { RedisClient } from './redis.js'
+
+const RENEW_SCRIPT = "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end"
+
+export type ExecutionLeaseLossReason = 'ownership_lost' | 'renewal_failed'
+
+export interface ExecutionLeaseGuard {
+  readonly signal: AbortSignal
+  confirmOwned(): Promise<boolean>
+  lossReason(): ExecutionLeaseLossReason
+  stop(): void
+}
+
+export interface ExecutionLeaseGuardOptions {
+  renewIntervalMs?: number
+  onLoss?: (reason: ExecutionLeaseLossReason, error?: unknown) => void
+}
+
+// Starts periodic renewal for a lock the caller has already acquired. The same atomic
+// compare-and-expire operation is exposed for an immediate pre-mutation ownership check.
+// Concurrent timer and dispatch checks share one Redis operation, avoiding overlapping
+// renewals while still failing closed on either a mismatch or an error.
+export function createExecutionLeaseGuard(
+  redis: RedisClient,
+  key: string,
+  owner: string,
+  ttlSeconds: number,
+  options: ExecutionLeaseGuardOptions = {},
+): ExecutionLeaseGuard {
+  const renewIntervalMs = options.renewIntervalMs ?? (ttlSeconds * 1000) / 3
+  if (!Number.isSafeInteger(ttlSeconds) || ttlSeconds < 1) throw new Error('Execution lease TTL must be a positive integer')
+  if (!Number.isFinite(renewIntervalMs) || renewIntervalMs <= 0 || renewIntervalMs >= ttlSeconds * 1000) {
+    throw new Error('Execution lease renewal interval must be positive and below its TTL')
+  }
+
+  const controller = new AbortController()
+  let reason: ExecutionLeaseLossReason = 'ownership_lost'
+  let stopped = false
+  let inFlight: Promise<boolean> | null = null
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  const lose = (nextReason: ExecutionLeaseLossReason, error?: unknown): false => {
+    if (stopped || controller.signal.aborted) return false
+    reason = nextReason
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+    controller.abort(nextReason)
+    options.onLoss?.(nextReason, error)
+    return false
+  }
+
+  const renew = async (): Promise<boolean> => {
+    if (stopped || controller.signal.aborted) return false
+    try {
+      const renewed = await redis.eval(RENEW_SCRIPT, 1, key, owner, ttlSeconds)
+      if (stopped) return false
+      return Number(renewed) === 1 || lose('ownership_lost')
+    } catch (error) {
+      return lose('renewal_failed', error)
+    }
+  }
+
+  const confirmOwned = (): Promise<boolean> => {
+    if (stopped || controller.signal.aborted) return Promise.resolve(false)
+    if (inFlight) return inFlight
+    inFlight = renew().finally(() => {
+      inFlight = null
+    })
+    return inFlight
+  }
+
+  timer = setInterval(() => void confirmOwned(), renewIntervalMs)
+  timer.unref()
+
+  return {
+    signal: controller.signal,
+    confirmOwned,
+    lossReason: () => reason,
+    stop(): void {
+      if (stopped) return
+      stopped = true
+      if (timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    },
+  }
+}

--- a/apps/api/src/operator-execution-lease.ts
+++ b/apps/api/src/operator-execution-lease.ts
@@ -32,8 +32,8 @@ export function createExecutionLeaseGuard(
   ttlSeconds: number,
   options: ExecutionLeaseGuardOptions = {},
 ): ExecutionLeaseGuard {
-  const renewIntervalMs = options.renewIntervalMs ?? (ttlSeconds * 1000) / 3
   if (!Number.isSafeInteger(ttlSeconds) || ttlSeconds < 1) throw new Error('Execution lease TTL must be a positive integer')
+  const renewIntervalMs = options.renewIntervalMs ?? (ttlSeconds * 1000) / 3
   if (!Number.isFinite(renewIntervalMs) || renewIntervalMs <= 0 || renewIntervalMs >= ttlSeconds * 1000) {
     throw new Error('Execution lease renewal interval must be positive and below its TTL')
   }

--- a/apps/api/src/operator-governed-execute.ts
+++ b/apps/api/src/operator-governed-execute.ts
@@ -231,8 +231,9 @@ export async function executeViaControlPlane(
       if (!settled.ok) {
         // The shared signal aborts an in-flight fetch. Its remote outcome cannot be
         // proven, so surface lease loss (not a generic transport error) and make retry
-        // unsafe until an operator reconciles the result.
-        if (lease?.signal.aborted) return leaseLoss(step, true)
+        // unsafe until an operator reconciles the result. A definitive rejection still
+        // proves nothing applied, even when it races with the lease-loss signal.
+        if (lease?.signal.aborted) return leaseLoss(step, settled.failure.terminal)
         return { applied, failure: settled.failure }
       }
       applied.push(settled.result)

--- a/apps/api/src/operator-governed-execute.ts
+++ b/apps/api/src/operator-governed-execute.ts
@@ -39,6 +39,26 @@ export interface GovernedStepFailure {
 export interface GovernedExecutionResult {
   applied: GovernedStepResult[]
   failure: GovernedStepFailure | null
+  // Lease loss is separate from a provider/control failure: it says this process no
+  // longer has authority to schedule the plan. outcomeUncertain is true only when loss
+  // happened while a mutation was already dispatched and its result was not observed.
+  leaseLoss?: GovernedLeaseLoss
+}
+
+export interface GovernedLeaseLoss {
+  stepId: string
+  capability: string
+  reason: 'ownership_lost' | 'renewal_failed'
+  outcomeUncertain: boolean
+}
+
+export interface GovernedExecutionLease {
+  signal: AbortSignal
+  // Atomically confirms that this request still owns the distributed lease. The route
+  // also renews the TTL in the same operation so a newly dispatched mutation remains
+  // protected for a full lease period.
+  confirmOwned: () => Promise<boolean>
+  lossReason: () => GovernedLeaseLoss['reason']
 }
 
 export interface GovernedPlanStep {
@@ -154,6 +174,7 @@ export async function executeViaControlPlane(
   client: ControlClient,
   steps: GovernedPlanStep[],
   priorOutputs: Record<string, Record<string, unknown>> = {},
+  lease?: GovernedExecutionLease,
 ): Promise<GovernedExecutionResult> {
   const applied: GovernedStepResult[] = []
   const outputs = new Map<string, Record<string, unknown>>(Object.entries(priorOutputs))
@@ -166,7 +187,19 @@ export async function executeViaControlPlane(
     }
   }
 
+  const leaseLoss = (step: GovernedPlanStep, outcomeUncertain = false): GovernedExecutionResult => ({
+    applied,
+    failure: null,
+    leaseLoss: {
+      stepId: step.id,
+      capability: step.capability,
+      reason: lease?.lossReason() ?? 'ownership_lost',
+      outcomeUncertain,
+    },
+  })
+
   for (const wave of waves) {
+    if (lease?.signal.aborted) return leaseLoss(wave[0])
     const reads = wave.filter((step) => CAPABILITIES[step.capability]?.mutating !== true)
     const writes = wave.filter((step) => CAPABILITIES[step.capability]?.mutating === true)
 
@@ -176,12 +209,36 @@ export async function executeViaControlPlane(
       if (settled.ok) applied.push(settled.result)
       else failure ??= settled.failure
     }
+    // A lease lost while reads were in flight stops the graph even when those harmless
+    // reads completed. No write from this or a later wave may be scheduled afterward.
+    if (lease?.signal.aborted) return leaseLoss(writes[0] ?? wave[0])
     if (failure) return { applied, failure }
 
     for (const step of writes) {
+      if (lease?.signal.aborted) return leaseLoss(step)
+      if (lease) {
+        let owned = false
+        try {
+          owned = await lease.confirmOwned()
+        } catch {
+          // A check error is uncertain ownership. The route aborts the shared signal and
+          // records the precise reason; the executor always fails closed either way.
+          owned = false
+        }
+        if (!owned || lease.signal.aborted) return leaseLoss(step)
+      }
       const settled = await applyStep(client, step, outputs)
-      if (!settled.ok) return { applied, failure: settled.failure }
+      if (!settled.ok) {
+        // The shared signal aborts an in-flight fetch. Its remote outcome cannot be
+        // proven, so surface lease loss (not a generic transport error) and make retry
+        // unsafe until an operator reconciles the result.
+        if (lease?.signal.aborted) return leaseLoss(step, true)
+        return { applied, failure: settled.failure }
+      }
       applied.push(settled.result)
+      // A client that does not honor AbortSignal may still return success after lease
+      // loss. Record the known success, but stop before another step is dispatched.
+      if (lease?.signal.aborted) return leaseLoss(step)
     }
   }
   return { applied, failure: null }

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -2238,8 +2238,10 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
         // A settled plan no longer needs its vaulted credentials: a full apply sealed them at
         // their final place through the provider create, and a spent plan (a recorded step
         // failure) can never be retried. Only a definitive, nothing-applied failure keeps them,
-        // so the retry the ledger permits still has its values.
-        if ((!result.failure && !result.leaseLoss) || result.failure?.terminal || result.leaseLoss?.outcomeUncertain) {
+        // so the retry the ledger permits still has its values. The spent test mirrors exactly
+        // when a failed execution turn was written above, since that turn is what blocks a re-run.
+        const spent = result.failure ? result.applied.length > 0 || result.failure.terminal : result.leaseLoss?.outcomeUncertain === true
+        if ((!result.failure && !result.leaseLoss) || spent) {
           await deletePlanSecrets(client, { conversationId: params.id, zoneId: params.zoneId, planSeq })
         }
         return { turns, outputs }

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -25,6 +25,7 @@ import { previewPlan, type StepPreview } from '../operator-preview.js'
 import { buildOperatorAuthority, isZoneIsolated, authorizePlanSteps, type OperatorAuthority } from '../operator-authority.js'
 import { buildOperatorControlClient, type OperatorControlEndpoints } from '../operator-control-client.js'
 import { executeViaControlPlane, type GovernedPlanStep } from '../operator-governed-execute.js'
+import { createExecutionLeaseGuard } from '../operator-execution-lease.js'
 import { isControlExecutable } from '../operator-control-map.js'
 import { SYSTEM_ZONE_SLUG } from '../system-zone.js'
 import {
@@ -995,6 +996,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
     authorizedBy?: string,
     coAuthorOperator?: boolean,
     requestId?: string,
+    signal?: AbortSignal,
   ): { client: ControlClient; identity: OperatorControlIdentity } | null => {
     const identity = opts.resolveControlIdentity?.() ?? null
     if (!identity || !opts.controlEndpoints) return null
@@ -1008,6 +1010,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       authorizedBy,
       coAuthorOperator,
       requestId,
+      signal,
     })
     return client ? { client, identity } : null
   }
@@ -1864,7 +1867,14 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
     // than applying changes as any other authority. There is no admin-actor fallback. The
     // executing actor's stable identity rides as the audit attribution so every governed mutation
     // in the tamper-evident control audit carries the profile id of the human who applied the plan.
-    const governed = resolveControlClient(params.zoneId, req.account?.id ?? `admin:${req.actor.id}`, true, req.id)
+    const executionLeaseController = new AbortController()
+    const governed = resolveControlClient(
+      params.zoneId,
+      req.account?.id ?? `admin:${req.actor.id}`,
+      true,
+      req.id,
+      executionLeaseController.signal,
+    )
     if (!governed) {
       return reply.code(409).send({ error: 'governed_execution_unconfigured' })
     }
@@ -1883,26 +1893,15 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
     const locked = await fastify.redis.set(lockKey, lockOwner, 'EX', EXECUTE_LOCK_TTL_SEC, 'NX')
     if (locked !== 'OK') return reply.code(409).send({ error: 'plan_already_executed' })
 
-    // The lock renews while this request still owns it, so an apply that legitimately runs
-    // longer than one TTL never loses its lock mid-flight, while an abandoned lock (a crashed
-    // holder stops renewing) still expires within one TTL.
-    const renewLock = setInterval(
-      () => {
-        fastify.redis
-          .eval(
-            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end",
-            1,
-            lockKey,
-            lockOwner,
-            EXECUTE_LOCK_TTL_SEC,
-          )
-          .then((renewed) => {
-            if (renewed !== 1) req.log.warn({ lockKey }, 'execute lock renewal skipped: lock no longer owned')
-          })
-          .catch((err) => req.log.warn({ err, lockKey }, 'execute lock renewal failed'))
+    // The lock renews while this request still owns it. Lost or uncertain ownership aborts
+    // the active control transport and becomes a hard scheduler stop, rather than a warning.
+    const executionLease = createExecutionLeaseGuard(fastify.redis, lockKey, lockOwner, EXECUTE_LOCK_TTL_SEC, {
+      onLoss: (reason, err) => {
+        if (reason === 'renewal_failed') req.log.warn({ err, lockKey }, 'execute lock renewal failed; stopping execution')
+        else req.log.warn({ lockKey }, 'execute lock ownership lost; stopping execution')
+        executionLeaseController.abort(reason)
       },
-      (EXECUTE_LOCK_TTL_SEC * 1000) / 3,
-    )
+    })
 
     try {
       // Pre-flight: read-only validation in one short transaction. Resolves the approved,
@@ -2098,7 +2097,11 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
       // a least-privilege token, resolves any references to earlier outputs, and invokes its
       // governed control command; the control plane authorizes, executes, and audits it natively.
       // A denial or failure stops the plan, so it never silently half-applies.
-      const result = await executeViaControlPlane(controlClient, pre.steps, pre.priorOutputs)
+      const result = await executeViaControlPlane(controlClient, pre.steps, pre.priorOutputs, {
+        signal: executionLease.signal,
+        confirmOwned: executionLease.confirmOwned,
+        lossReason: executionLease.lossReason,
+      })
 
       // Record the applied steps and any failure in the ledger. The control plane already
       // wrote the tamper-evident admin audit for each mutation, so no manual audit record
@@ -2183,18 +2186,60 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
             actorId: req.actor.id,
           })
         }
+        if (result.leaseLoss) {
+          // If ownership disappeared during a dispatched mutation, its remote outcome is
+          // ambiguous. Persist a failed execution marker so no replica can retry that step
+          // and possibly apply it twice. A pre-dispatch stop remains safely resumable.
+          if (result.leaseLoss.outcomeUncertain) {
+            await writeTurnLocked(client, {
+              conversationId: params.id,
+              zoneId: params.zoneId,
+              seq,
+              role: 'operator',
+              kind: 'execution',
+              contentJson: JSON.stringify({
+                plan_seq: planSeq,
+                step_id: result.leaseLoss.stepId,
+                status: 'failed',
+                detail: 'Execution lease was lost while this step was in flight; its outcome is uncertain.',
+                executed_by: authority.principal,
+              }),
+              actorId: req.actor.id,
+            })
+            seq += 1
+          }
+          await writeTurnLocked(client, {
+            conversationId: params.id,
+            zoneId: params.zoneId,
+            seq,
+            role: 'system',
+            kind: 'error',
+            contentJson: JSON.stringify({
+              message:
+                result.leaseLoss.reason === 'renewal_failed'
+                  ? 'Execution stopped because distributed lock ownership could not be confirmed.'
+                  : 'Execution stopped because distributed lock ownership was lost.',
+              code: 'execution_lease_lost',
+              reason: result.leaseLoss.reason,
+              plan_seq: planSeq,
+              step_id: result.leaseLoss.stepId,
+              outcome_uncertain: result.leaseLoss.outcomeUncertain,
+            }),
+            actorId: req.actor.id,
+          })
+        }
         // A clean apply is durable, governed knowledge of the zone: record it as a persistent,
         // zone-scoped memory so a later conversation recalls what was configured here. Memory is
         // written only for a fully applied plan, inside this transaction, so it reflects an
         // approved outcome Caracal actually applied - never a proposal or a partial failure.
-        if (!result.failure && result.applied.length > 0) {
+        if (!result.failure && !result.leaseLoss && result.applied.length > 0) {
           await rememberAppliedChange(client, params.zoneId, params.id, pre.summary)
         }
         // A settled plan no longer needs its vaulted credentials: a full apply sealed them at
         // their final place through the provider create, and a spent plan (a recorded step
         // failure) can never be retried. Only a definitive, nothing-applied failure keeps them,
         // so the retry the ledger permits still has its values.
-        if (!result.failure || result.applied.length > 0 || result.failure.terminal) {
+        if ((!result.failure && !result.leaseLoss) || result.failure?.terminal || result.leaseLoss?.outcomeUncertain) {
           await deletePlanSecrets(client, { conversationId: params.id, zoneId: params.zoneId, planSeq })
         }
         return { turns, outputs }
@@ -2202,6 +2247,15 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
 
       if (result.failure) {
         return reply.code(422).send({ error: 'execution_failed', step_id: result.failure.stepId, applied: recorded.turns })
+      }
+      if (result.leaseLoss) {
+        return reply.code(result.leaseLoss.reason === 'renewal_failed' ? 503 : 409).send({
+          error: 'execution_lease_lost',
+          reason: result.leaseLoss.reason,
+          step_id: result.leaseLoss.stepId,
+          outcome_uncertain: result.leaseLoss.outcomeUncertain,
+          applied: recorded.turns,
+        })
       }
 
       // Return the applied result immediately - including any one-time output such as an issued
@@ -2273,7 +2327,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
 
       return reply
     } finally {
-      clearInterval(renewLock)
+      executionLease.stop()
       // Release the lock only if this request still owns it: a compare-and-delete so an
       // expired-then-reacquired lock held by another request is never deleted here. A failed
       // release is logged - the lock still expires on its TTL, but the delay is visible.

--- a/apps/api/src/routes/operator.ts
+++ b/apps/api/src/routes/operator.ts
@@ -25,7 +25,7 @@ import { previewPlan, type StepPreview } from '../operator-preview.js'
 import { buildOperatorAuthority, isZoneIsolated, authorizePlanSteps, type OperatorAuthority } from '../operator-authority.js'
 import { buildOperatorControlClient, type OperatorControlEndpoints } from '../operator-control-client.js'
 import { executeViaControlPlane, type GovernedPlanStep } from '../operator-governed-execute.js'
-import { createExecutionLeaseGuard } from '../operator-execution-lease.js'
+import { createExecutionLeaseGuard, type ExecutionLeaseGuard } from '../operator-execution-lease.js'
 import { isControlExecutable } from '../operator-control-map.js'
 import { SYSTEM_ZONE_SLUG } from '../system-zone.js'
 import {
@@ -1893,17 +1893,17 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
     const locked = await fastify.redis.set(lockKey, lockOwner, 'EX', EXECUTE_LOCK_TTL_SEC, 'NX')
     if (locked !== 'OK') return reply.code(409).send({ error: 'plan_already_executed' })
 
-    // The lock renews while this request still owns it. Lost or uncertain ownership aborts
-    // the active control transport and becomes a hard scheduler stop, rather than a warning.
-    const executionLease = createExecutionLeaseGuard(fastify.redis, lockKey, lockOwner, EXECUTE_LOCK_TTL_SEC, {
-      onLoss: (reason, err) => {
-        if (reason === 'renewal_failed') req.log.warn({ err, lockKey }, 'execute lock renewal failed; stopping execution')
-        else req.log.warn({ lockKey }, 'execute lock ownership lost; stopping execution')
-        executionLeaseController.abort(reason)
-      },
-    })
-
+    let executionLease: ExecutionLeaseGuard | null = null
     try {
+      // The lock renews while this request still owns it. Lost or uncertain ownership aborts
+      // the active control transport and becomes a hard scheduler stop, rather than a warning.
+      executionLease = createExecutionLeaseGuard(fastify.redis, lockKey, lockOwner, EXECUTE_LOCK_TTL_SEC, {
+        onLoss: (reason, err) => {
+          if (reason === 'renewal_failed') req.log.warn({ err, lockKey }, 'execute lock renewal failed; stopping execution')
+          else req.log.warn({ lockKey }, 'execute lock ownership lost; stopping execution')
+          executionLeaseController.abort(reason)
+        },
+      })
       // Pre-flight: read-only validation in one short transaction. Resolves the approved,
       // not-yet-executed, still-valid, still-unblocked plan to the steps to execute. It
       // writes nothing, so the governed control calls below run outside any transaction.
@@ -2255,6 +2255,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
           step_id: result.leaseLoss.stepId,
           outcome_uncertain: result.leaseLoss.outcomeUncertain,
           applied: recorded.turns,
+          outputs: recorded.outputs,
         })
       }
 
@@ -2327,7 +2328,7 @@ export const operatorRoutes: FastifyPluginAsync<OperatorRoutesOptions> = async (
 
       return reply
     } finally {
-      executionLease.stop()
+      executionLease?.stop()
       // Release the lock only if this request still owns it: a compare-and-delete so an
       // expired-then-reacquired lock held by another request is never deleted here. A failed
       // release is logged - the lock still expires on its TTL, but the delay is visible.

--- a/apps/web/src/platform/api/hooks.ts
+++ b/apps/web/src/platform/api/hooks.ts
@@ -417,6 +417,10 @@ const STALE_PLAN_CODES = new Set([
   // ledger error turn, so re-reading the timeline settles the card on the real, audited failure
   // detail and surfaces that error through the same notice channel as every other failure.
   "execution_failed",
+  // Execution stopped because this replica lost the distributed lock. The server recorded every
+  // step it did apply plus the lease-loss error turn, so the timeline holds the authoritative
+  // outcome and the card must settle on it rather than on a plan it thinks is still pending.
+  "execution_lease_lost",
 ]);
 
 function resyncOnStalePlan(

--- a/apps/web/src/platform/operator/view.ts
+++ b/apps/web/src/platform/operator/view.ts
@@ -173,6 +173,13 @@ export function executeErrorMessage(err: unknown): string {
       return "The zone changed since this plan was approved, so applying it now would do something the approval never covered. Ask again to compose a fresh plan.";
     case "conversation_archived":
       return "This conversation is archived, so it can't apply changes.";
+    // Caracal stopped mid-apply because this server lost the lock that authorized the run. A step
+    // caught in flight has an unknown result, so the plan is closed and the operator has to check
+    // what landed; a stop before dispatch changed nothing further and stays applicable.
+    case "execution_lease_lost":
+      return (err as { detail?: { outcome_uncertain?: boolean } } | null)?.detail?.outcome_uncertain
+        ? "Caracal lost the lock on this run while a change was in flight, so it can't tell whether that step applied. Check the timeline above for what landed - this plan can't be applied again."
+        : "Caracal lost the lock on this run and stopped before applying anything further. Nothing beyond the steps above changed, so you can apply the rest again.";
     default:
       return "Couldn't apply the changes. Please try again.";
   }

--- a/tests/typescript/unit/api/operator-control-client.test.ts
+++ b/tests/typescript/unit/api/operator-control-client.test.ts
@@ -61,4 +61,28 @@ describe('buildOperatorControlClient', () => {
     expect(fetchMock.mock.calls[0]![0]).toBe('https://sts.example.com/oauth/2/token')
     expect(fetchMock.mock.calls[1]![0]).toBe('http://127.0.0.1:3000/v1/control/invoke')
   })
+
+  it('propagates caller cancellation into an in-flight governed request', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true })
+      })
+      return new Response()
+    })
+    const client = buildOperatorControlClient({
+      identity,
+      role: 'executor',
+      endpoints: endpoints(),
+      signal: controller.signal,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    })
+
+    const invoking = client!.invoke('app', 'create', { name: 'blocked' }, ['control:app:write'])
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    controller.abort('execution lease lost')
+
+    await expect(invoking).rejects.toMatchObject({ stage: 'token', status: 0 })
+    expect((fetchMock.mock.calls[0]![1] as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
 })

--- a/tests/typescript/unit/api/operator-execution-lease.test.ts
+++ b/tests/typescript/unit/api/operator-execution-lease.test.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Garudex Labs.  All Rights Reserved.
+// Caracal, a product of Garudex Labs
+//
+// Unit tests for fail-closed Operator plan-execution lease renewal.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createExecutionLeaseGuard } from '../../../../apps/api/src/operator-execution-lease.js'
+import type { RedisClient } from '../../../../apps/api/src/redis.js'
+
+function redisWithEval(evalFn: ReturnType<typeof vi.fn>): RedisClient {
+  return { eval: evalFn } as unknown as RedisClient
+}
+
+afterEach(() => vi.useRealTimers())
+
+describe('Operator execution lease guard', () => {
+  it('aborts periodic work when Redis reports that ownership was lost', async () => {
+    vi.useFakeTimers()
+    const onLoss = vi.fn()
+    const evalFn = vi.fn().mockResolvedValue(0)
+    const lease = createExecutionLeaseGuard(redisWithEval(evalFn), 'operator:exec:z:c:1', 'owner-a', 1, {
+      renewIntervalMs: 100,
+      onLoss,
+    })
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(lease.signal.aborted).toBe(true)
+    expect(lease.lossReason()).toBe('ownership_lost')
+    expect(onLoss).toHaveBeenCalledWith('ownership_lost', undefined)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(evalFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a renewal exception as uncertain ownership and aborts', async () => {
+    vi.useFakeTimers()
+    const error = new Error('redis unavailable')
+    const onLoss = vi.fn()
+    const evalFn = vi.fn().mockRejectedValue(error)
+    const lease = createExecutionLeaseGuard(redisWithEval(evalFn), 'operator:exec:z:c:1', 'owner-a', 1, {
+      renewIntervalMs: 100,
+      onLoss,
+    })
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(lease.signal.aborted).toBe(true)
+    expect(lease.lossReason()).toBe('renewal_failed')
+    expect(onLoss).toHaveBeenCalledWith('renewal_failed', error)
+  })
+
+  it('prevents a former holder from confirming after a competing owner takes the lock', async () => {
+    let currentOwner = 'owner-a'
+    const evalFn = vi.fn(async (_script: string, _keys: number, _key: string, owner: string) => (owner === currentOwner ? 1 : 0))
+    const redis = redisWithEval(evalFn)
+    const former = createExecutionLeaseGuard(redis, 'operator:exec:z:c:1', 'owner-a', 60, { renewIntervalMs: 10_000 })
+    const competitor = createExecutionLeaseGuard(redis, 'operator:exec:z:c:1', 'owner-b', 60, { renewIntervalMs: 10_000 })
+
+    await expect(former.confirmOwned()).resolves.toBe(true)
+    currentOwner = 'owner-b'
+    await expect(competitor.confirmOwned()).resolves.toBe(true)
+    await expect(former.confirmOwned()).resolves.toBe(false)
+
+    expect(former.signal.aborted).toBe(true)
+    expect(competitor.signal.aborted).toBe(false)
+    former.stop()
+    competitor.stop()
+  })
+
+  it('shares concurrent ownership confirmations and stops its timer idempotently', async () => {
+    vi.useFakeTimers()
+    let resolveCheck: ((value: number) => void) | undefined
+    const evalFn = vi.fn(() => new Promise<number>((resolve) => (resolveCheck = resolve)))
+    const lease = createExecutionLeaseGuard(redisWithEval(evalFn), 'operator:exec:z:c:1', 'owner-a', 1, { renewIntervalMs: 100 })
+
+    const first = lease.confirmOwned()
+    const second = lease.confirmOwned()
+    expect(evalFn).toHaveBeenCalledTimes(1)
+    resolveCheck?.(1)
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+
+    lease.stop()
+    lease.stop()
+    await vi.advanceTimersByTimeAsync(500)
+    expect(evalFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/typescript/unit/api/operator-execution-lease.test.ts
+++ b/tests/typescript/unit/api/operator-execution-lease.test.ts
@@ -81,6 +81,7 @@ describe('Operator execution lease guard', () => {
 
     lease.stop()
     lease.stop()
+    await expect(lease.confirmOwned()).resolves.toBe(false)
     await vi.advanceTimersByTimeAsync(500)
     expect(evalFn).toHaveBeenCalledTimes(1)
   })

--- a/tests/typescript/unit/api/operator-governed-execute.test.ts
+++ b/tests/typescript/unit/api/operator-governed-execute.test.ts
@@ -326,4 +326,57 @@ describe('executeViaControlPlane', () => {
     expect(result.failure).toBeNull()
     expect(result.leaseLoss).toMatchObject({ stepId: 's1', reason: 'ownership_lost', outcomeUncertain: true })
   })
+
+  it('keeps a definitive rejection resumable when it races with lease loss', async () => {
+    const controller = new AbortController()
+    const client: ControlClient = {
+      invoke: vi.fn(async () => {
+        controller.abort('ownership_lost')
+        throw new ControlClientError('invoke', 403, 'request denied', 'denied')
+      }),
+    }
+    const result = await executeViaControlPlane(
+      client,
+      [{ id: 's1', capability: 'registerApplication', args: { name: 'denied' } }],
+      {},
+      {
+        signal: controller.signal,
+        confirmOwned: async () => true,
+        lossReason: () => 'ownership_lost',
+      },
+    )
+
+    expect(result.failure).toBeNull()
+    expect(result.leaseLoss).toMatchObject({ stepId: 's1', reason: 'ownership_lost', outcomeUncertain: false })
+  })
+
+  it('does not dispatch a write after lease loss during a read wave', async () => {
+    const controller = new AbortController()
+    const invoked: string[] = []
+    const client: ControlClient = {
+      invoke: vi.fn(async (command, subcommand) => {
+        invoked.push(`${command}:${subcommand}`)
+        controller.abort('ownership_lost')
+        return []
+      }),
+    }
+    const result = await executeViaControlPlane(
+      client,
+      [
+        { id: 'read', capability: 'listApplications', args: {} },
+        { id: 'write', capability: 'registerApplication', args: { name: 'never-started' } },
+      ],
+      {},
+      {
+        signal: controller.signal,
+        confirmOwned: async () => true,
+        lossReason: () => 'ownership_lost',
+      },
+    )
+
+    expect(invoked).toEqual(['app:list'])
+    expect(result.applied.map((step) => step.id)).toEqual(['read'])
+    expect(result.failure).toBeNull()
+    expect(result.leaseLoss).toMatchObject({ stepId: 'write', outcomeUncertain: false })
+  })
 })

--- a/tests/typescript/unit/api/operator-governed-execute.test.ts
+++ b/tests/typescript/unit/api/operator-governed-execute.test.ts
@@ -235,4 +235,95 @@ describe('executeViaControlPlane', () => {
     expect(invokeFail.calls).toHaveLength(1)
     expect(stopped.failure).toMatchObject({ stepId: 's1', terminal: true })
   })
+
+  it('stops before the next mutation when lease ownership is lost', async () => {
+    const controller = new AbortController()
+    const { client, calls } = fakeClient([{ id: 'app-1' }, { id: 'app-2' }])
+    let confirmations = 0
+    const result = await executeViaControlPlane(
+      client,
+      [
+        { id: 's1', capability: 'registerApplication', args: { name: 'first' } },
+        { id: 's2', capability: 'registerApplication', args: { name: 'second' } },
+      ],
+      {},
+      {
+        signal: controller.signal,
+        confirmOwned: async () => {
+          confirmations += 1
+          if (confirmations === 1) return true
+          controller.abort('ownership_lost')
+          return false
+        },
+        lossReason: () => 'ownership_lost',
+      },
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(result.applied.map((step) => step.id)).toEqual(['s1'])
+    expect(result.failure).toBeNull()
+    expect(result.leaseLoss).toEqual({
+      stepId: 's2',
+      capability: 'registerApplication',
+      reason: 'ownership_lost',
+      outcomeUncertain: false,
+    })
+  })
+
+  it('fails closed without dispatch when the ownership check errors', async () => {
+    const controller = new AbortController()
+    const { client, calls } = fakeClient([{ id: 'app-1' }])
+    const result = await executeViaControlPlane(
+      client,
+      [{ id: 's1', capability: 'registerApplication', args: { name: 'blocked' } }],
+      {},
+      {
+        signal: controller.signal,
+        confirmOwned: async () => {
+          controller.abort('renewal_failed')
+          throw new Error('redis unavailable')
+        },
+        lossReason: () => 'renewal_failed',
+      },
+    )
+
+    expect(calls).toHaveLength(0)
+    expect(result.failure).toBeNull()
+    expect(result.leaseLoss).toMatchObject({ stepId: 's1', reason: 'renewal_failed', outcomeUncertain: false })
+  })
+
+  it('marks the outcome uncertain when lease loss aborts an in-flight mutation', async () => {
+    const controller = new AbortController()
+    let rejectInvoke: ((error: Error) => void) | undefined
+    const client: ControlClient = {
+      invoke: vi.fn(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectInvoke = reject
+          }),
+      ),
+    }
+    const running = executeViaControlPlane(
+      client,
+      [
+        { id: 's1', capability: 'registerApplication', args: { name: 'in-flight' } },
+        { id: 's2', capability: 'registerApplication', args: { name: 'never-started' } },
+      ],
+      {},
+      {
+        signal: controller.signal,
+        confirmOwned: async () => true,
+        lossReason: () => 'ownership_lost',
+      },
+    )
+    await vi.waitFor(() => expect(client.invoke).toHaveBeenCalledTimes(1))
+    controller.abort('ownership_lost')
+    rejectInvoke?.(new ControlClientError('invoke', 0, 'aborted'))
+    const result = await running
+
+    expect(client.invoke).toHaveBeenCalledTimes(1)
+    expect(result.applied).toHaveLength(0)
+    expect(result.failure).toBeNull()
+    expect(result.leaseLoss).toMatchObject({ stepId: 's1', reason: 'ownership_lost', outcomeUncertain: true })
+  })
 })

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -1555,6 +1555,105 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     expect(invokeCommands).not.toContain('app')
   })
 
+  it('discards vaulted credentials when a definitive failure follows an already-applied step', async () => {
+    // An applied step makes the route record a failed execution turn for the definitive rejection,
+    // which blocks every re-run. The plan is therefore spent and its sealed credentials must be
+    // wiped immediately rather than left for the reaper's TTL.
+    const twoGrantPlan = {
+      summary: 'Grant access',
+      steps: [
+        {
+          id: 's1',
+          capability: 'grantAccess',
+          mutating: true,
+          args: { application_id: 'app-1', user_id: 'user-1', resource_id: 'res-1', scopes: ['invoices.read'] },
+        },
+        {
+          id: 's2',
+          capability: 'grantAccess',
+          mutating: true,
+          args: { application_id: 'app-1', user_id: 'user-1', resource_id: 'res-2', scopes: ['invoices.write'] },
+        },
+      ],
+    }
+    let invokes = 0
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/oauth/2/token')) return jsonResponse({ access_token: 'control-token' })
+      if (url.endsWith('/v1/control/invoke')) {
+        invokes += 1
+        if (invokes === 1) return jsonResponse({ result: { id: 'grant-xyz' } })
+        return jsonResponse({ error: { reason: 'missing scope control:grant:write', code: 'forbidden' } }, 403)
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    const { app, clientQuery } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    clientQuery
+      // pre-flight
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }) // conv status
+      .mockResolvedValueOnce({ rows: [{ content: twoGrantPlan }] }) // plan content
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] }) // approved
+      .mockResolvedValueOnce({ rows: [] }) // not executed
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] }) // preview: application lives (s1)
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] }) // preview: resource lives (s1)
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] }) // preview: application lives (s2)
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] }) // preview: resource lives (s2)
+      .mockResolvedValueOnce(undefined) // COMMIT
+      // recording
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 5 }] }) // conv FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance for the applied step
+      .mockResolvedValueOnce({ rows: [{ id: 'applied-turn' }] }) // INSERT execution turn (s1)
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance for the failed step
+      .mockResolvedValueOnce({ rows: [{ id: 'failed-turn' }] }) // INSERT execution turn (s2)
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance for the system error turn
+      .mockResolvedValueOnce({ rows: [{ id: 'error-turn' }] }) // INSERT error turn
+      .mockResolvedValueOnce({ rows: [] }) // DELETE settled plan vault rows
+      .mockResolvedValueOnce(undefined) // COMMIT
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+    expect(res.statusCode).toBe(422)
+    expect(JSON.parse(res.body)).toMatchObject({ error: 'execution_failed', step_id: 's2' })
+    expect(clientQuery.mock.calls.some((c) => String(c[0]).includes('DELETE FROM operator_plan_secrets'))).toBe(true)
+  })
+
+  it('keeps vaulted credentials when a lease stop before dispatch leaves the plan resumable', async () => {
+    // Nothing was dispatched, so no failed execution turn is written and the plan can be applied
+    // again. Its sealed credentials must survive so the retry the ledger permits still has them.
+    const fetchMock = controlFetch([{ id: 'grant-xyz' }])
+    const { app, clientQuery, redis } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    redis.eval.mockResolvedValueOnce(0)
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN (pre-flight)
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [{ content: grantPlan }] })
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce(undefined) // COMMIT
+      .mockResolvedValueOnce(undefined) // BEGIN (record stop)
+      .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 5 }] })
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance sequence
+      .mockResolvedValueOnce({ rows: [{ id: 'error-turn' }] }) // insert error turn
+      .mockResolvedValueOnce(undefined) // COMMIT
+
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(clientQuery.mock.calls.some((c) => String(c[0]).includes('DELETE FROM operator_plan_secrets'))).toBe(false)
+  })
+
   it('refuses an approved plan the Operator is not authorized to execute', async () => {
     const { app, clientQuery } = buildApp(true, { ...governedControl, allowedCapabilities: ['registerApplication'] })
     const forbiddenPlan = {

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -1661,6 +1661,78 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     expect(redis.eval).toHaveBeenCalled()
   })
 
+  it('stops before dispatch and reports lost lease ownership clearly', async () => {
+    const fetchMock = controlFetch([{ id: 'grant-xyz' }])
+    const { app, clientQuery, redis } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    redis.eval.mockResolvedValueOnce(0)
+    clientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN (pre-flight)
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [{ content: grantPlan }] })
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce(undefined) // COMMIT
+      .mockResolvedValueOnce(undefined) // BEGIN (record stop)
+      .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 5 }] })
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance sequence
+      .mockResolvedValueOnce({ rows: [{ id: 'error-turn' }] }) // insert error turn
+      .mockResolvedValueOnce(undefined) // COMMIT
+
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'execution_lease_lost',
+      reason: 'ownership_lost',
+      step_id: 's1',
+      outcome_uncertain: false,
+      applied: [],
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+    const errorInsert = clientQuery.mock.calls.find(
+      (call) => String(call[0]).includes('INSERT INTO operator_turns') && String(call[1]?.[5]) === 'error',
+    )
+    expect(String(errorInsert?.[1]?.[6])).toContain('execution_lease_lost')
+  })
+
+  it('treats a Redis ownership-check error as uncertain ownership and fails closed', async () => {
+    const fetchMock = controlFetch([{ id: 'grant-xyz' }])
+    const { app, clientQuery, redis } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    redis.eval.mockRejectedValueOnce(new Error('redis unavailable'))
+    clientQuery
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [{ content: grantPlan }] })
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 5 }] })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 'error-turn' }] })
+      .mockResolvedValueOnce(undefined)
+
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+
+    expect(res.statusCode).toBe(503)
+    expect(JSON.parse(res.body)).toMatchObject({ error: 'execution_lease_lost', reason: 'renewal_failed', outcome_uncertain: false })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('records durable conversation memory of a plan it actually applied', async () => {
     const fetchMock = controlFetch([{ id: 'grant-xyz' }])
     const { app, clientQuery } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })

--- a/tests/typescript/unit/api/routes/operator.test.ts
+++ b/tests/typescript/unit/api/routes/operator.test.ts
@@ -3,7 +3,7 @@
 //
 // Operator Control API route unit tests: conversation ledger lifecycle and append-only turns.
 
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import Fastify from 'fastify'
 import type { DB } from '../../../../../apps/api/src/db.js'
 import type { RedisClient } from '../../../../../apps/api/src/redis.js'
@@ -19,6 +19,11 @@ import type { OperatorRunLimiter } from '../../../../../apps/api/src/operator-ru
 
 // Test-only deterministic KEK fixture (32-byte hex) so the plan credential vault can seal. Never use in production.
 process.env.SECRET_STORE_KEK = '8f3d9a71c2b44e5f96a103d7be28cc41d5f09ab6731e4c8f2a7db56019ce34af'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 function buildApp(
   enabled = true,
@@ -1731,6 +1736,67 @@ describe('POST /v1/zones/:zoneId/operator-conversations/:id/plan/execute', () =>
     expect(res.statusCode).toBe(503)
     expect(JSON.parse(res.body)).toMatchObject({ error: 'execution_lease_lost', reason: 'renewal_failed', outcome_uncertain: false })
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('marks an in-flight mutation uncertain and non-retriable when periodic renewal loses ownership', async () => {
+    let triggerRenewal: (() => void) | undefined
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (!String(input).endsWith('/oauth/2/token')) throw new Error(`unexpected fetch ${String(input)}`)
+      await new Promise<void>((resolve) => {
+        init?.signal?.addEventListener('abort', resolve, { once: true })
+        triggerRenewal?.()
+      })
+      throw init?.signal?.reason
+    })
+    const { app, clientQuery, redis } = buildApp(true, { ...governedControl, fetchImpl: fetchMock as unknown as typeof fetch })
+    // The immediate pre-write confirmation succeeds; the periodic renewal then observes
+    // that a competing holder owns the lock while the token request is in flight.
+    redis.eval.mockResolvedValueOnce(1).mockResolvedValueOnce(0).mockResolvedValue(0)
+    clientQuery
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] })
+      .mockResolvedValueOnce({ rows: [{ content: grantPlan }] })
+      .mockResolvedValueOnce({ rows: [{ kind: 'approval' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ one: 1 }] })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined) // BEGIN (record uncertain stop)
+      .mockResolvedValueOnce({ rows: [{ status: 'active', next_seq: 5 }] })
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance for failed execution turn
+      .mockResolvedValueOnce({ rows: [{ id: 'failed-turn' }] })
+      .mockResolvedValueOnce({ rowCount: 1 }) // advance for system error turn
+      .mockResolvedValueOnce({ rows: [{ id: 'error-turn' }] })
+      .mockResolvedValueOnce({ rows: [] }) // delete plan secrets
+      .mockResolvedValueOnce(undefined) // COMMIT
+
+    await app.ready()
+    const realSetInterval = globalThis.setInterval
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (timeout !== 40_000) return realSetInterval(handler, timeout, ...args)
+      triggerRenewal = () => {
+        if (typeof handler === 'function') handler(...args)
+      }
+      return realSetInterval(() => {}, timeout)
+    }) as typeof setInterval)
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/zones/z1/operator-conversations/conv-1/plan/execute',
+      payload: { plan_seq: 2 },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'execution_lease_lost',
+      reason: 'ownership_lost',
+      step_id: 's1',
+      outcome_uncertain: true,
+    })
+    const executionInsert = clientQuery.mock.calls.find(
+      (call) => String(call[0]).includes('INSERT INTO operator_turns') && String(call[1]?.[5]) === 'execution',
+    )
+    expect(String(executionInsert?.[1]?.[6])).toContain('"status":"failed"')
+    expect(clientQuery.mock.calls.some((call) => String(call[0]).includes('DELETE FROM operator_plan_secrets'))).toBe(true)
   })
 
   it('records durable conversation memory of a plan it actually applied', async () => {

--- a/tests/typescript/unit/web/operatorView.test.ts
+++ b/tests/typescript/unit/web/operatorView.test.ts
@@ -201,6 +201,12 @@ describe('executeErrorMessage', () => {
     expect(executeErrorMessage({ code: 'plan_state_changed' })).toContain('zone changed since this plan was approved')
     expect(executeErrorMessage({ code: 'plan_blocked' })).toContain("can't be applied")
   })
+  it('separates a resumable lease stop from one whose in-flight step is unknown', () => {
+    expect(executeErrorMessage({ code: 'execution_lease_lost', detail: { outcome_uncertain: false } })).toContain(
+      'you can apply the rest again',
+    )
+    expect(executeErrorMessage({ code: 'execution_lease_lost', detail: { outcome_uncertain: true } })).toContain("can't be applied again")
+  })
   it('falls back for unknown codes', () => {
     expect(executeErrorMessage({ code: 'mystery' })).toBe("Couldn't apply the changes. Please try again.")
     expect(executeErrorMessage(null)).toBe("Couldn't apply the changes. Please try again.")


### PR DESCRIPTION
Closes #410

## Summary

- replace warn-only execution-lock renewal with a fail-closed lease guard
- abort in-flight governed control transport when ownership is lost or Redis renewal fails
- atomically confirm and renew ownership before every mutating plan step
- stop dependency-wave scheduling after lease loss and distinguish definitive rejection from outcome-uncertain in-flight loss
- persist a correlated execution_lease_lost error, prevent unsafe retry, and preserve outputs from known successful steps

## Validation

- pnpm run style
- pnpm --dir apps/api build
- pnpm --dir apps/api test (1,448 passed, 1 skipped)
- focused lease/control/executor/route suite repeated 10 times on the final review-fix commit (173 tests per run, all passed)
- targeted ESLint and git diff --check
- GitHub TypeScript CI, Stack E2E, migrations, CodeQL, Semgrep, style, and CodeRabbit all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Added safeguards to detect lost execution ownership and stop further changes safely.
  * Improved handling of interrupted operations, clearly distinguishing retryable results from uncertain outcomes.
  * Added cancellation support for in-progress control requests.

* **User Experience**
  * Added clearer messages when execution ownership is lost.
  * Automatically refreshes the conversation timeline to show the latest execution state.

* **Bug Fixes**
  * Improved cleanup and retry behavior after partial or interrupted executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->